### PR TITLE
Add return type in API documentation doclet

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/APIDocumentationDoclet.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/APIDocumentationDoclet.java
@@ -12,10 +12,22 @@ import java.text.BreakIterator;
  * them.  It is used for grading a student's Javadocs.
  *
  * @author David Whitlock
- * @version $Revision: 1.1 $
  * @since Summer 2004
  */
+@SuppressWarnings("UnusedDeclaration")
 public class APIDocumentationDoclet {
+
+  /**
+   * NOTE: Without this method present and returning LanguageVersion.JAVA_1_5,
+   * Javadoc will not process generics because it assumes LanguageVersion.JAVA_1_1.
+   *
+   * Note that 1.5 is as high as the <code>LanguageVersion</code> goes.
+   *
+   * @return language version (hard coded to LanguageVersion.JAVA_1_5)
+   */
+  public static LanguageVersion languageVersion() {
+    return LanguageVersion.JAVA_1_5;
+  }
 
   /**
    * This doclet has no valid options
@@ -35,7 +47,7 @@ public class APIDocumentationDoclet {
 
   /**
    * Print out a summary of each class, field, and method to standard
-   * out. 
+   * out.
    */
   public static boolean start(RootDoc root) {
     PrintWriter pw = new PrintWriter(System.out, true);
@@ -68,7 +80,7 @@ public class APIDocumentationDoclet {
     BreakIterator boundary = BreakIterator.getWordInstance();
     boundary.setText(text);
     int start = boundary.first();
-    for (int end = boundary.next(); end != BreakIterator.DONE; 
+    for (int end = boundary.next(); end != BreakIterator.DONE;
          start = end, end = boundary.next()) {
 
       String word = text.substring(start, end);
@@ -123,6 +135,7 @@ public class APIDocumentationDoclet {
   private static void generate(ExecutableMemberDoc m, PrintWriter pw) {
     StringBuilder sb = new StringBuilder();
     sb.append(m.modifiers()).append(" ");
+    appendTypeVariables(m.typeParameters(), sb);
     appendReturnType(m, sb);
     sb.append(m.name());
     sb.append("(");
@@ -162,14 +175,53 @@ public class APIDocumentationDoclet {
 
   }
 
+  private static void appendTypeVariables(TypeVariable[] variables, StringBuilder sb) {
+    if (variables.length > 0) {
+      sb.append("<");
+
+      for (int i = 0; i < variables.length; i++) {
+        TypeVariable variable = variables[i];
+        appendType(variable, sb);
+
+        if (i < variables.length - 1) {
+          sb.append(", ");
+        }
+      }
+
+      sb.append("> ");
+    }
+  }
+
   private static void appendReturnType(ExecutableMemberDoc m, StringBuilder sb) {
     if (m instanceof MethodDoc) {
       MethodDoc method = (MethodDoc) m;
-      if (method.isAbstract()) {
-        sb.append("abstract ");
-      }
+      appendType(method.returnType(), sb).append(" ");
+    }
+  }
 
-      sb.append(method.returnType().typeName()).append(" ");
+  private static StringBuilder appendType(Type type, StringBuilder sb) {
+    sb.append(type.qualifiedTypeName());
+
+    ParameterizedType parameterizedType = type.asParameterizedType();
+    if (parameterizedType != null) {
+      appendTypeArguments(parameterizedType.typeArguments(), sb);
+    }
+
+    return sb;
+  }
+
+  private static void appendTypeArguments(Type[] typeArguments, StringBuilder sb) {
+    if (typeArguments.length >0) {
+      sb.append("<");
+      for (int i = 0; i < typeArguments.length; i++) {
+        Type typeArgument = typeArguments[i];
+        sb.append(typeArgument.qualifiedTypeName());
+
+        if (i < typeArguments.length - 1) {
+          sb.append(", ");
+        }
+      }
+      sb.append(">");
     }
   }
 


### PR DESCRIPTION
In order to address issue #82, the return type of methods is not outputted by the `APIDocumentationDoclet`. I also added support for outputting information about the type parameters for method parameters and return type.
