### PR TITLE
Add a doUnexpectedFailure method to GWT RemoteServiceServlets.

### DIFF
--- a/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
+++ b/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
@@ -14,10 +14,22 @@ import ${package}.client.PingService;
  */
 public class PingServiceImpl extends RemoteServiceServlet implements PingService
 {
-    public AbstractAirline ping()
-    {
-        Airline airline = new Airline();
-        airline.addFlight( new Flight() );
-        return airline;
-    }
+  @Override
+  public AbstractAirline ping() {
+    Airline airline = new Airline();
+    airline.addFlight(new Flight());
+    return airline;
+  }
+
+  /**
+   * Log unhandled exceptions to standard error
+   *
+   * @param unhandled
+   *        The exception that wasn't handled
+   */
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
 }

--- a/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
+++ b/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
@@ -14,10 +14,17 @@ import ${package}.client.PingService;
  */
 public class PingServiceImpl extends RemoteServiceServlet implements PingService
 {
-    public AbstractAppointmentBook ping()
-    {
-        AppointmentBook book = new AppointmentBook();
-        book.addAppointment( new Appointment() );
-        return book;
-    }
+  @Override
+  public AbstractAppointmentBook ping() {
+    AppointmentBook book = new AppointmentBook();
+    book.addAppointment(new Appointment());
+    return book;
+  }
+
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
+
 }

--- a/gwt-parent/familygwt/src/main/java/edu/pdx/cs410J/family/gwt/server/FamilyTreeServiceImpl.java
+++ b/gwt-parent/familygwt/src/main/java/edu/pdx/cs410J/family/gwt/server/FamilyTreeServiceImpl.java
@@ -9,7 +9,15 @@ import edu.pdx.cs410J.family.web.FamilyTreeManager;
  * Server-side implementation of {@link FamilyTreeService}
  */
 public class FamilyTreeServiceImpl extends RemoteServiceServlet implements FamilyTreeService {
+  @Override
   public FamilyTree getFamilyTree() {
     return FamilyTreeManager.getFamilyTree(getThreadLocalRequest());
   }
+
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
+
 }

--- a/gwt-parent/gwt/src/main/java/edu/pdx/cs410J/gwt/server/DivisionServiceImpl.java
+++ b/gwt-parent/gwt/src/main/java/edu/pdx/cs410J/gwt/server/DivisionServiceImpl.java
@@ -7,7 +7,15 @@ import edu.pdx.cs410J.gwt.client.DivisionService;
  * The server-side implementation of the division service
  */
 public class DivisionServiceImpl extends RemoteServiceServlet implements DivisionService {
+  @Override
   public int divide(int dividend, int divisor) {
     return dividend / divisor;
   }
+
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
+
 }

--- a/gwt-parent/gwt/src/main/java/edu/pdx/cs410J/gwt/server/di/GuiceRemoteServiceServlet.java
+++ b/gwt-parent/gwt/src/main/java/edu/pdx/cs410J/gwt/server/di/GuiceRemoteServiceServlet.java
@@ -66,4 +66,10 @@ public class GuiceRemoteServiceServlet extends RemoteServiceServlet {
   private RemoteService getServiceInstance(Class serviceClass) {
     return (RemoteService) injector.get().getInstance(serviceClass);
   }
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
+
 }

--- a/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
+++ b/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/server/PingServiceImpl.java
@@ -16,11 +16,22 @@ import java.lang.Override;
  */
 public class PingServiceImpl extends RemoteServiceServlet implements PingService
 {
-    @Override
-    public AbstractPhoneBill ping()
-    {
-        PhoneBill phonebill = new PhoneBill();
-        phonebill.addPhoneCall(new PhoneCall());
-        return phonebill;
-    }
+  @Override
+  public AbstractPhoneBill ping() {
+    PhoneBill phonebill = new PhoneBill();
+    phonebill.addPhoneCall(new PhoneCall());
+    return phonebill;
+  }
+
+  /**
+   * Log unhandled exceptions to standard error
+   *
+   * @param unhandled
+   *        The exception that wasn't handled
+   */
+  @Override
+  protected void doUnexpectedFailure(Throwable unhandled) {
+    unhandled.printStackTrace(System.err);
+    super.doUnexpectedFailure(unhandled);
+  }
 }


### PR DESCRIPTION
Override the doUnexpectedFailure method in GWT RemoteServiceServlet subclasses so that uncaught exceptions thrown by GWT server-side services are logged.  This addresses issue #78.
