### PR TITLE
Use ${gwt.version} for the version of the gwt-maven-plugin

### DIFF
--- a/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -57,7 +57,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>2.6.0</version>
+          <version>${gwt.version}</version>
             <configuration>
                 <runTarget>${package}.AirlineGwt/AirlineGwt.html</runTarget>
                 <modules>

--- a/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -57,7 +57,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>${gwt.version}</version>
             <configuration>
                 <runTarget>${package}.AppointmentBookGwt/AppointmentBookGwt.html</runTarget>
                 <modules>

--- a/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -63,7 +63,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>${gwt.version}</version>
             <configuration>
                 <runTarget>${package}.PhoneBillGwt/PhoneBillGwt.html</runTarget>
                 <modules>


### PR DESCRIPTION
Found a couple of places that hard-code the version of the Maven GWT plugin and replaced them with the ${gwt.version} variable.  This addresses issue #58.
