### PR TITLE
Warn if main project class not submitted

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -403,7 +403,19 @@ public class Submit extends EmailSender {
 
     out.println("A receipt will be sent to: " + userEmail + "\n");
 
+    warnIfMainProjectClassIsNotSubmitted(sourceFiles);
+
     return doesUserWantToSubmit();
+  }
+
+  private void warnIfMainProjectClassIsNotSubmitted(Set<File> sourceFiles) {
+    boolean wasMainProjectClassSubmitted = sourceFiles.stream().anyMatch((f) -> f.getName().contains(this.projName));
+    if (!wasMainProjectClassSubmitted) {
+      String mainProjectClassName = this.projName + ".java";
+      out.println("*** WARNING: You are submitting " + this.projName +
+        ", but did not include " + mainProjectClassName + ".\n" +
+        "    You might want to check the name of the project or the files you are submitting.\n");
+    }
   }
 
   private boolean doesUserWantToSubmit() {


### PR DESCRIPTION
To address issue #69, I added a warning to the `Submit` program that informs the submitted when they do not include the main class for the project.  That is, if the student is submitting `Project1` and does not submit `Project1.java`, an warning will be issued/
