### PR TITLE
Update versions of dependencies and Maven plugins

### DIFF
--- a/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -62,15 +62,11 @@
         </plugin>
 
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -84,6 +84,9 @@
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <webApp>
+            <contextPath>/airline</contextPath>
+          </webApp>
         </configuration>
       </plugin>
       <plugin>

--- a/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -77,15 +77,11 @@
         <version>2.1.1</version>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>${http.port}</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>
@@ -117,7 +113,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.13</version>
         <executions>
           <execution>
             <id>start-container</id>
@@ -136,7 +132,7 @@
         </executions>
         <configuration>
           <container>
-            <containerId>jetty6x</containerId>
+            <containerId>jetty9x</containerId>
             <type>embedded</type>
             <systemProperties>
               <org.apache.commons.logging.Log>

--- a/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -62,15 +62,11 @@
         </plugin>
 
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -76,15 +76,11 @@
         <version>2.1.1</version>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>${http.port}</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>
@@ -116,7 +112,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.13</version>
         <executions>
           <execution>
             <id>start-container</id>
@@ -135,7 +131,7 @@
         </executions>
         <configuration>
           <container>
-            <containerId>jetty6x</containerId>
+            <containerId>jetty9x</containerId>
             <type>embedded</type>
             <systemProperties>
               <org.apache.commons.logging.Log>

--- a/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -83,6 +83,9 @@
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <webApp>
+            <contextPath>/apptbook</contextPath>
+          </webApp>
         </configuration>
       </plugin>
       <plugin>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.5-beta</version>
+      <version>2.0.7-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
     <dependency>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>2.0</version>
+      <version>4.0-beta5</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.0.5-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.9.3</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -53,17 +53,17 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>18.0</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.0.5-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>2.0</version>
+      <version>4.0-beta5</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.5-beta</version>
+      <version>2.0.7-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gwt-parent/familygwt/pom.xml
+++ b/gwt-parent/familygwt/pom.xml
@@ -63,15 +63,11 @@
           </executions>
         </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -99,15 +99,11 @@
         </plugin>
 
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -8,7 +8,6 @@
     <version>Summer2015</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>edu.pdx.cs410J</groupId>
   <artifactId>gwt</artifactId>
   <packaging>war</packaging>
   <version>Summer2015</version>
@@ -142,14 +141,6 @@
               </sources>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.8</version>
-        <executions>
           <execution>
             <id>add-it-resources</id>
             <phase>generate-test-resources</phase>
@@ -166,7 +157,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 </project>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.0.5-beta</version>
+      <version>2.0.7-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -30,6 +30,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
+      <!-- Gin doesn't work with Guice 4.0 yet -->
       <version>3.0</version>
     </dependency>
     <dependency>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -19,13 +19,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.0.5-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>18.0</version>
       <!-- Can't use guava in GWT client code yet -->
     </dependency>
     <dependency>

--- a/gwt-parent/pom.xml
+++ b/gwt-parent/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -68,15 +68,11 @@
         </plugin>
 
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -76,15 +76,11 @@
         <version>2.1.1</version>
       </plugin>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>${http.port}</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>
@@ -116,7 +112,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.13</version>
         <executions>
           <execution>
             <id>start-container</id>
@@ -135,7 +131,7 @@
         </executions>
         <configuration>
           <container>
-            <containerId>jetty6x</containerId>
+            <containerId>jetty9x</containerId>
             <type>embedded</type>
             <systemProperties>
               <org.apache.commons.logging.Log>

--- a/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -83,6 +83,9 @@
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <webApp>
+            <contextPath>/phonebill</contextPath>
+          </webApp>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version> <!-- Need version 2.1.1 for Java 7 -->
+        <version>2.6</version>
         <configuration>
           <archive>
             <manifest>

--- a/projects/pom.xml
+++ b/projects/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -176,7 +176,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -13,7 +13,7 @@
   <version>Summer2015</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
-    <resteasy.version>2.3.3.Final</resteasy.version>
+    <resteasy.version>3.0.11.Final</resteasy.version>
   </properties>
   <build>
     <finalName>web</finalName>
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.13</version>
         <executions>
           <execution>
             <id>start-container</id>
@@ -71,7 +71,7 @@
         </executions>
         <configuration>
           <container>
-            <containerId>jetty6x</containerId>
+            <containerId>jetty9x</containerId>
             <type>embedded</type>
             <systemProperties>
               <org.apache.commons.logging.Log>
@@ -213,12 +213,12 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>2.0</version>
+      <version>4.0-beta5</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
-      <version>2.0</version>
+      <version>4.0-beta5</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -19,15 +19,11 @@
     <finalName>web</finalName>
     <plugins>
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-        <version>6.1.26</version>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.2.10.v20150310</version>
         <configuration>
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>8080</port>
-            </connector>
-          </connectors>
+          <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
         </configuration>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -227,7 +227,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>18.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/web/src/main/java/edu/pdx/cs410J/di/CreditCardDatabase.java
+++ b/web/src/main/java/edu/pdx/cs410J/di/CreditCardDatabase.java
@@ -1,8 +1,8 @@
 package edu.pdx.cs410J.di;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
-import com.google.inject.internal.Maps;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.annotation.XmlAttribute;


### PR DESCRIPTION
Update the version of the library dependencies and Maven plugins in order to address #102.  I also updated the version of Resteasy used by the `web` example to address #27.