### PR TITLE
Update java koans with latest from matyb

### DIFF
--- a/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,6 +60,15 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.3.1</version>
           <executions>

--- a/java-koans-archetype/src/main/resources/archetype-resources/src/java7/AboutTryWithResources.java
+++ b/java-koans-archetype/src/main/resources/archetype-resources/src/java7/AboutTryWithResources.java
@@ -12,6 +12,27 @@ import static com.sandwich.util.Assert.assertEquals;
 
 public class AboutTryWithResources {
 
+    class AutoClosableResource implements AutoCloseable{
+        public void foo() throws WorkException{
+            throw new WorkException("Exception thrown while working");
+        }
+        public void close() throws CloseException{
+            throw new CloseException("Exception thrown while closing");
+        }
+    }
+
+    class WorkException extends Exception {
+        public WorkException(String message) {
+            super(message);
+        }
+    }
+
+    class CloseException extends Exception {
+        public CloseException(String message) {
+            super(message);
+        }
+    }
+
     @Koan
     public void lookMaNoClose() {
         String str = "first line"
@@ -33,11 +54,13 @@ public class AboutTryWithResources {
 
     @Koan
     public void lookMaNoCloseWithException() throws IOException {
-        String line;
+        String line = "no need to close readers";
         try (BufferedReader br =
                      new BufferedReader(
                              new FileReader("I do not exist!"))) {
             line = br.readLine();
+        }catch(FileNotFoundException e){
+            line = "no more leaking!";
         }
         assertEquals(line, __);
     }
@@ -84,26 +107,5 @@ public class AboutTryWithResources {
                      new AutoClosableResource()) {
             autoClosableResource.foo();
         }
-    }
-}
-
-class AutoClosableResource implements AutoCloseable{
-    public void foo() throws WorkException{
-        throw new WorkException("Exception thrown while working");
-    }
-    public void close() throws CloseException{
-        throw new CloseException("Exception thrown while closing");
-    }
-}
-
-class WorkException extends Exception {
-    public WorkException(String message) {
-        super(message);
-    }
-}
-
-class CloseException extends Exception {
-    public CloseException(String message) {
-        super(message);
     }
 }

--- a/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutDefaultMethods.java
+++ b/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutDefaultMethods.java
@@ -8,26 +8,6 @@ import com.sandwich.koan.Koan;
 import static com.sandwich.koan.constant.KoanConstants.__;
 import static com.sandwich.util.Assert.assertEquals;
 
-
-interface StringUtil {
-
-    //static method in interface
-    static String enclose(String in){
-        return "[" + in + "]";
-    }
-
-    String reverse(String s);
-
-    //interface can contain non-abstract method implementations marked by "default" keyword
-    default String capitalize(String s) {
-        return s.toUpperCase();
-    }
-
-    default String capitalizeFirst(String s) {
-        return s.substring(0, 1).toUpperCase() + s.substring(1);
-    }
-}
-
 public class AboutDefaultMethods {
 
     @Koan
@@ -46,6 +26,25 @@ public class AboutDefaultMethods {
     @Koan
     public void interfaceStaticMethod() {
         assertEquals(StringUtil.enclose("me"), __);
+    }
+
+    interface StringUtil {
+
+        //static method in interface
+        static String enclose(String in){
+            return "[" + in + "]";
+        }
+
+        String reverse(String s);
+
+        //interface can contain non-abstract method implementations marked by "default" keyword
+        default String capitalize(String s) {
+            return s.toUpperCase();
+        }
+
+        default String capitalizeFirst(String s) {
+            return s.substring(0, 1).toUpperCase() + s.substring(1);
+        }
     }
 
 }

--- a/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutLambdas.java
+++ b/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutLambdas.java
@@ -11,11 +11,11 @@ import java.util.function.Predicate;
 import static com.sandwich.util.Assert.assertEquals;
 import static com.sandwich.koan.constant.KoanConstants.__;
 
-interface Caps {
-    public String capitalize(String name);
-}
-
 public class AboutLambdas {
+
+    interface Caps {
+        public String capitalize(String name);
+    }
 
     String fieldFoo = "Lambdas";
 

--- a/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutMultipleInheritance.java
+++ b/java-koans-archetype/src/main/resources/archetype-resources/src/java8/AboutMultipleInheritance.java
@@ -8,28 +8,28 @@ import com.sandwich.koan.Koan;
 import static com.sandwich.util.Assert.assertEquals;
 import static com.sandwich.koan.constant.KoanConstants.__;
 
-interface Human{
-    default String sound(){
-        return "hello";
-    }
-}
-
-interface Bull{
-    default String sound(){
-        return "moo";
-    }
-}
-
-class Minotaur implements Human, Bull{
-    //both interfaces implement same default method
-    //has to be overridden
-    @Override
-    public String sound(){
-        return Bull.super.sound();
-    }
-}
-
 public class AboutMultipleInheritance {
+    
+    interface Human{
+        default String sound(){
+            return "hello";
+        }
+    }
+
+    interface Bull{
+        default String sound(){
+            return "moo";
+        }
+    }
+
+    class Minotaur implements Human, Bull{
+        //both interfaces implement same default method
+        //has to be overridden
+        @Override
+        public String sound(){
+            return Bull.super.sound();
+        }
+    }
 
     @Koan
     public void multipleInheritance(){


### PR DESCRIPTION
Somehow a couple of changes to the upstream Koans source code slipped past me.  These changes address #109 by including those changes in the archetype.  I've verified that a newly-created project from the updated archetype does not show https://github.com/matyb/java-koans/issues/49.