### PR TITLE
One more fix for submitting koans

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -474,8 +474,13 @@ public class Submit extends EmailSender {
    * directory.
    */
   private String getRelativeName(File file) {
-    // We already know that the file is in the correct directory
-    return "edu/pdx/cs410J/" + userId + "/" + file.getName();
+    if (isSubmittingKoans) {
+      return file.getParentFile().getName() + "/" + file.getName();
+
+    } else {
+      // We already know that the file is in the correct directory
+      return "edu/pdx/cs410J/" + userId + "/" + file.getName();
+    }
   }
 
   /**


### PR DESCRIPTION
When submitting koans, make sure that the entry in the jar file matches the path to the file.  This goes towards fixing issue #111.