### PR TITLE
Don't let student submit a program with a nine-digit log in

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/GradeBook.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/GradeBook.java
@@ -345,6 +345,10 @@ public class GradeBook {
     return this.assignments.values().stream();
   }
 
+  public Optional<Student> getStudentWithSsn(String ssn) {
+    return this.studentsStream().filter(s -> ssn.equals(s.getSsn())).findAny();
+  }
+
   static class LetterGradeRanges implements Iterable<LetterGradeRanges.LetterGradeRange> {
     private final Map<LetterGrade, LetterGradeRange> ranges = new TreeMap<>();
 

--- a/grader/src/main/java/edu/pdx/cs410J/grader/ProjectGradesImporter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/ProjectGradesImporter.java
@@ -55,6 +55,9 @@ public class ProjectGradesImporter {
 
     Optional<Student> maybeStudent = gradeBook.getStudent(studentId);
     if (!maybeStudent.isPresent()) {
+      maybeStudent = gradeBook.getStudentWithSsn(studentId);
+    }
+    if (!maybeStudent.isPresent()) {
       warn("Student \"" + studentId + "\" not found in gradebook");
       return;
     }

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Student.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Student.java
@@ -147,9 +147,10 @@ public class Student extends NotableImpl {
   /**
    * Sets the social security number of this <code>Student</code>
    */
-  public void setSsn(String ssn) {
+  public Student setSsn(String ssn) {
     this.setDirty(true);
     this.ssn = ssn;
+    return this;
   }
 
   /**

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Student.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Student.java
@@ -39,9 +39,9 @@ public class Student extends NotableImpl {
    */
   public Student(String id) {
     this.id = id;
-    this.grades = new TreeMap<String, Grade>();
-    this.late = new ArrayList<String>();
-    this.resubmitted = new ArrayList<String>();
+    this.grades = new TreeMap<>();
+    this.late = new ArrayList<>();
+    this.resubmitted = new ArrayList<>();
   }
 
   ///////////////////////  Instance Methods  ///////////////////////
@@ -105,17 +105,17 @@ public class Student extends NotableImpl {
    * last, and nick names.
    */
   public String getFullName() {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     if (this.firstName != null) {
       sb.append(this.firstName);
     }
 
     if (this.nickName != null) {
-      sb.append(" \"" + this.nickName + "\"");
+      sb.append(" \"").append(this.nickName).append("\"");
     }
 
     if (this.lastName != null) {
-      sb.append(" " + this.lastName);
+      sb.append(" ").append(this.lastName);
     }
 
     return sb.toString().trim();
@@ -232,9 +232,7 @@ public class Student extends NotableImpl {
 	  super.makeClean();
 
     // Make all Grades clean
-    for (Grade grade : this.grades.values()) {
-      grade.makeClean();
-    }
+    this.grades.values().forEach(edu.pdx.cs410J.grader.Grade::makeClean);
   }
 
   /**
@@ -263,29 +261,27 @@ public class Student extends NotableImpl {
   String getDescription() {
     Student student = this;
 
-    StringBuffer sb = new StringBuffer();
-    sb.append(student.getId() + ": ");
+    StringBuilder sb = new StringBuilder();
+    sb.append(student.getId()).append(": ");
     sb.append(student.getFullName());
 
     String email = student.getEmail();
     if (email != null && !email.equals("")) {
-      sb.append(", " + email);
+      sb.append(", ").append(email);
     }
 
     String ssn = student.getSsn();
     if (ssn != null && !ssn.equals("")) {
-      sb.append(", " + ssn);
+      sb.append(", ").append(ssn);
     }
 
     String major = student.getMajor();
     if (major != null && !major.equals("")) {
-      sb.append(", " + major);
+      sb.append(", ").append(major);
     }
 
-    Iterator iter = this.getNotes().iterator();
-    while (iter.hasNext()) {
-      String note = (String) iter.next();
-      sb.append(", \"" + note + "\"");
+    for (Object note : this.getNotes()) {
+      sb.append(", \"").append(note).append("\"");
     }
 
     return sb.toString();
@@ -297,12 +293,7 @@ public class Student extends NotableImpl {
    * Two <code>Student</code>s are equal if they have the same id
    */
   public boolean equals(Object o) {
-    if (o instanceof Student) {
-      return this.getId().equals(((Student) o).getId());
-
-    } else {
-      return false;
-    }
+    return o instanceof Student && this.getId().equals(((Student) o).getId());
   }
 
   /**

--- a/grader/src/main/java/edu/pdx/cs410J/grader/StudentFileMailer.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/StudentFileMailer.java
@@ -105,6 +105,9 @@ public class StudentFileMailer extends EmailSender {
       String studentId = getStudentIdFromFileName(file);
       Optional<Student> maybeStudent = gradeBook.getStudent(studentId);
       if (!maybeStudent.isPresent()) {
+        maybeStudent = gradeBook.getStudentWithSsn(studentId);
+      }
+      if (!maybeStudent.isPresent()) {
         cannotFindStudent(studentId);
       } else {
         filesToSendToStudents.put(maybeStudent.get(), file);

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -1,5 +1,7 @@
 package edu.pdx.cs410J.grader;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
 import javax.activation.FileDataSource;
@@ -200,6 +202,10 @@ public class Submit extends EmailSender {
       throw new IllegalStateException("Missing login id");
     }
 
+    if (isNineDigitStudentId(userId)) {
+      throw new IllegalStateException(loginIdShouldNotBeStudentId(userId));
+    }
+
     if (userEmail == null) {
       throw new IllegalStateException("Missing email address");
 
@@ -215,6 +221,15 @@ public class Submit extends EmailSender {
         throw ex2;
       }
     }
+  }
+
+  @VisibleForTesting
+  boolean isNineDigitStudentId(String userId) {
+    return userId.matches("^[0-9]{9}$");
+  }
+
+  private String loginIdShouldNotBeStudentId(String userId) {
+    return "Your login id (" + userId + ") should not be your 9-digit student id";
   }
 
   private void validateProjectName() {

--- a/grader/src/test/java/edu/pdx/cs410J/grader/GradeBookTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/GradeBookTest.java
@@ -116,4 +116,19 @@ public class GradeBookTest {
     assertThat(book.getLetterGradeForScore(99.0), equalTo(LetterGrade.A));
     assertThat(book.getLetterGradeForScore(93.0), equalTo(LetterGrade.A_MINUS));
   }
+
+  @Test
+  public void getStudentBySsnForNonExistentStudentReturnsNonPresentOptional() {
+    GradeBook book = new GradeBook("test");
+    assertThat(book.getStudentWithSsn("123").isPresent(), equalTo(false));
+  }
+
+  @Test
+  public void getStudentBySsnForStudentReturnsStudent() {
+    GradeBook book = new GradeBook("test");
+    String ssn = "123456789";
+    Student student = new Student("id").setSsn(ssn);
+    book.addStudent(student);
+    assertThat(book.getStudentWithSsn(ssn).get(), equalTo(student));
+  }
 }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
@@ -1,0 +1,27 @@
+package edu.pdx.cs410J.grader;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class SubmitTest {
+
+  @Test
+  public void nineDigitStringIsInvalidLoginId() {
+    Submit submit = new Submit();
+    assertThat(submit.isNineDigitStudentId("123456789"), equalTo(true));
+  }
+
+  @Test
+  public void eightDigitStringIsValidLoginId() {
+    Submit submit = new Submit();
+    assertThat(submit.isNineDigitStudentId("12345678"), equalTo(false));
+  }
+
+  @Test
+  public void userNameIsValidLoginId() {
+    Submit submit = new Submit();
+    assertThat(submit.isNineDigitStudentId("whitlock"), equalTo(false));
+  }
+}

--- a/gwt-parent/pom.xml
+++ b/gwt-parent/pom.xml
@@ -48,16 +48,19 @@
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-servlet</artifactId>
+        <version>${gwt.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-user</artifactId>
+        <version>${gwt.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-dev</artifactId>
+        <version>${gwt.version}</version>
         <scope>test</scope><!-- Needed for running GwtTests in IntelliJ -->
       </dependency>
       <dependency>


### PR DESCRIPTION
Address issue #120 by preventing a student from submitting a project with a login id that is nine digits.  This nine-digit string is most likely their student id which is not the same as their login id.  I also made the "send a student a file" and "record grade from report" programs able to handle files whose name contain the nine-digit student id.