### PR TITLE
Compile GWT code with Java 7 language level

### DIFF
--- a/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,6 +51,7 @@
                 <extraJvmArgs>-Xmx512m</extraJvmArgs>
                 <style>DETAILED</style>
                 <copyWebapp>true</copyWebapp>
+                <sourceLevel>${gwt.client.source.level}</sourceLevel>
             </configuration>
           <executions>
             <execution>

--- a/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,6 +51,7 @@
                 <extraJvmArgs>-Xmx512m</extraJvmArgs>
                 <style>DETAILED</style>
                 <copyWebapp>true</copyWebapp>
+                <sourceLevel>${gwt.client.source.level}</sourceLevel>
             </configuration>
           <executions>
             <execution>

--- a/gwt-parent/familygwt/pom.xml
+++ b/gwt-parent/familygwt/pom.xml
@@ -53,6 +53,7 @@
             <extraJvmArgs>-Xmx512m</extraJvmArgs>
             <style>DETAILED</style>
             <copyWebapp>true</copyWebapp>
+            <sourceLevel>${gwt.client.source.level}</sourceLevel>
           </configuration>
           <executions>
             <execution>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -72,6 +72,7 @@
                 <module>edu.pdx.cs410J.gwt.Examples</module>
                 <style>PRETTY</style>
                 <copyWebapp>true</copyWebapp>
+                <sourceLevel>${gwt.client.source.level}</sourceLevel>
             </configuration>
           <executions>
             <execution>

--- a/gwt-parent/pom.xml
+++ b/gwt-parent/pom.xml
@@ -27,9 +27,10 @@
 
         <gwt.version>2.7.0</gwt.version>
 
-        <!--  GWT doesn't work with Java 8 yet -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <!--  GWT server-side code can use Java 8 -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <gwt.client.source.level>1.7</gwt.client.source.level>
     </properties>
 
     <dependencyManagement>

--- a/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -62,6 +62,7 @@
                 <extraJvmArgs>-Xmx512m</extraJvmArgs>
                 <style>DETAILED</style>
                 <copyWebapp>true</copyWebapp>
+                <sourceLevel>${gwt.client.source.level}</sourceLevel>
             </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Address issue #124 by setting the language level for GWT-compiled code to Java 7, but compiling server-side code with Java 8.