### PR TITLE
Get findbugs working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
-script: "mvn install site"
+script: "mvn install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
-script: "mvn install"
+script: "mvn install site"

--- a/examples/src/main/java/edu/pdx/cs410J/j2se15/CovariantReturns.java
+++ b/examples/src/main/java/edu/pdx/cs410J/j2se15/CovariantReturns.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs410J.j2se15;
 
 /**
- * This class demonstrates <I>covariant returns<I> in JDK 1.5.  The
+ * This class demonstrates <I>covariant returns</I> in JDK 1.5.  The
  * Java compiler allows an overriding method to change the method's
  * return type to be a subclass of the overriden method's return
  * type.  However, you have to be extra careful when using covariant

--- a/examples/src/test/java/edu/pdx/cs410J/junit/HamcrestMatchersTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/junit/HamcrestMatchersTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * This test demonstrates the use of various matchers from the Hamcrest library
  * for performing more advanced assertions in unit tests.
  *
- * <a href="http://hamcrest.org/JavaHamcrest"></a>http://hamcrest.org/JavaHamcrest</a>
+ * <a href="http://hamcrest.org/JavaHamcrest">http://hamcrest.org/JavaHamcrest</a>
  *
  * @since Summer 2013
  */

--- a/family/src/main/java/edu/pdx/cs410J/family/PersonMain.java
+++ b/family/src/main/java/edu/pdx/cs410J/family/PersonMain.java
@@ -7,7 +7,7 @@ import java.text.ParseException;
  * A class with a main method for testing {@link Person}.  Once upon a time,
  * this functionality was part of the <code>Person</code> class.  However,
  * since GWT <a href="http://code.google.com/p/bunsenandbeaker/wiki/DevGuideDateAndNumberFormat">cannot
- * handle <code>DateFormat</code> on the client side, I had to move it to
+ * handle</a> <code>DateFormat</code> on the client side, I had to move it to
  * its own class.
  *
  * @since Summer 2008 

--- a/family/src/main/java/edu/pdx/cs410J/family/RemoteMarriageImpl.java
+++ b/family/src/main/java/edu/pdx/cs410J/family/RemoteMarriageImpl.java
@@ -6,7 +6,7 @@ import java.util.Date;
 /**
  * This is class implements the <code>RemoteMarriage</code> interface.
  * Basically, it delegates all of its behavior to an underlying {@link
- * edu.pdx.cs410J.Marriage} that lives only on the server.
+ * edu.pdx.cs410J.family.Marriage} that lives only on the server.
  */
 @SuppressWarnings("serial")
 class RemoteMarriageImpl extends java.rmi.server.UnicastRemoteObject

--- a/family/src/main/java/edu/pdx/cs410J/family/XmlRemoteFamilyTree.java
+++ b/family/src/main/java/edu/pdx/cs410J/family/XmlRemoteFamilyTree.java
@@ -7,14 +7,7 @@ import java.rmi.Naming;
 import java.rmi.RMISecurityManager;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
-
-import edu.pdx.cs410J.ParserException;
+import java.util.*;
 
 /**
  * This class is a remote family tree whose contents are read from and
@@ -49,7 +42,7 @@ public class XmlRemoteFamilyTree extends UnicastRemoteObject
    * Creates a new <code>XmlRemoteFamilyTree</code> that gets its data
    * from a given XML file.
    *
-   * @throws ParserException
+   * @throws FamilyTreeException
    *         A problem occurred while parsing the XML file
    */
   public XmlRemoteFamilyTree(File xmlFile) 

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -27,11 +27,9 @@ import java.util.stream.Stream;
  * searched recursively for files ending in .java.  Those files are
  * placed in a zip file and emailed to the grader.  A confirmation
  * email is sent to the submitter.
- * <p/>
- * <p/>
- * <p/>
+ *
  * More information about the JavaMail API can be found at:
- * <p/>
+ *
  * <center><a href="http://java.sun.com/products/javamail">
  * http://java.sun.com/products/javamail</a></center>
  *

--- a/grader/src/main/java/edu/pdx/cs410J/grader/SubmitTask.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/SubmitTask.java
@@ -33,6 +33,7 @@ import java.util.List;
  * <h3>Parameters</h3>
  * 
  * <table border="1" cellpadding="2" cellspacing="0">
+ *  <caption>Properties of this Ant Task</caption>
  *  <tr>
  *    <td valign="top"><b>Attribute</b></td>
  *    <td valign="top"><b>Description</b></td>

--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -165,6 +165,12 @@
           </deployables>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -166,6 +166,12 @@
           </deployables>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -167,6 +167,12 @@
           </deployables>
         </configuration>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -175,6 +175,12 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>1.8</version>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -348,18 +348,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.10.3</version>
         <configuration>
           <aggregate>true</aggregate>
           <linksource>true</linksource>
           <overview>overview.html</overview>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api</link>
-            <link>http://download.oracle.com/javaee/6/api</link>
-            <link>http://junit.sourceforge.net/javadoc</link>
+            <link>http://download.oracle.com/javase/8/docs/api</link>
+            <link>http://download.oracle.com/javaee/7/api</link>
+            <link>http://junit.org/javadoc/latest</link>
             <link>http://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet</link>
             <link>http://www.jajakarta.org/ant/ant-1.6.1/docs/en/manual/api</link>
             <link>http://www.gwtproject.org/javadoc/latest</link>
+            <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
           </links>
         </configuration>
         <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,31 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>2.8.1</version>
+          <!-- In order to get the project info reports to work with Java 8 bytecode,
+               we need to use a different version of the bcel library -->
+          <dependencies>
+              <dependency>
+                  <groupId>org.apache.maven.shared</groupId>
+                  <artifactId>maven-shared-jar</artifactId>
+                  <version>1.1</version>
+                  <exclusions>
+                      <exclusion>
+                          <groupId>org.apache.bcel</groupId>
+                          <artifactId>bcel</artifactId>
+                      </exclusion>
+                  </exclusions>
+              </dependency>
+              <dependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>bcel-findbugs</artifactId>
+                  <version>6.0</version>
+              </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -355,9 +355,9 @@
             <link>http://download.oracle.com/javase/6/docs/api</link>
             <link>http://download.oracle.com/javaee/6/api</link>
             <link>http://junit.sourceforge.net/javadoc</link>
-            <link>http://java.sun.com/j2se/1.4.2/docs/tooldocs/javadoc/doclet</link>
-            <link>http://www.jakarta.org/ant/ant-1.6.1/docs/en/manual/api</link>
-            <link>http://google-web-toolkit.googlecode.com/svn/javadoc/1.6</link>
+            <link>http://docs.oracle.com/javase/8/docs/jdk/api/javadoc/doclet</link>
+            <link>http://www.jajakarta.org/ant/ant-1.6.1/docs/en/manual/api</link>
+            <link>http://www.gwtproject.org/javadoc/latest</link>
           </links>
         </configuration>
         <reportSets>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,16 @@
   </build>
   <reporting>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.3</version>
+        <configuration>
+          <xmlOutput>true</xmlOutput>
+          <!-- Optional directory to put findbugs xdoc xml report -->
+          <xmlOutputDirectory>target/site</xmlOutputDirectory>
+        </configuration>
+      </plugin>
       <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -330,13 +340,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jdepend-maven-plugin</artifactId>
         <version>2.0-beta-2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,35 +56,7 @@
         <name>CS410J Maven Repository</name>
         <url>http://web.cecs.pdx.edu/~whitlock/repository/maven2</url>
       </repository>
-      <repository>
-        <id>Codehaus Snapshots</id>
-        <name>Codehaus Snapshots</name>
-        <url>http://snapshots.maven.codehaus.org</url>
-        <releases>
-          <enabled>false</enabled>
-          <updatePolicy>always</updatePolicy>
-          <checksumPolicy>warn</checksumPolicy>
-        </releases>
-        <snapshots>
-          <enabled>false</enabled>
-          <updatePolicy>never</updatePolicy>
-          <checksumPolicy>fail</checksumPolicy>
-        </snapshots>
-        <layout>default</layout>
-      </repository>
     </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>Codehaus Plugin Snapshots</id>
-      <url>http://snapshots.repository.codehaus.org/</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,11 @@
           <xmlOutputDirectory>target/site</xmlOutputDirectory>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.6</version>
+      </plugin>
       <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -329,12 +334,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <targetJdk>1.5f</targetJdk>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -109,28 +109,6 @@
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
           <configuration>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -149,11 +149,6 @@
        </plugin>
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>3.1</version>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-project-info-reports-plugin</artifactId>
          <version>2.7</version>
        </plugin>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -109,28 +109,6 @@
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
           <configuration>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -149,11 +149,6 @@
        </plugin>
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>3.1</version>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-project-info-reports-plugin</artifactId>
          <version>2.7</version>
        </plugin>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -109,28 +109,6 @@
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
           <configuration>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -147,11 +147,6 @@
          <artifactId>maven-checkstyle-plugin</artifactId>
          <version>2.9</version>
        </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>2.7.1</version>
-       </plugin>
     </plugins>
   </reporting>
   <profiles>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -114,11 +114,6 @@
          </plugin>
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-pmd-plugin</artifactId>
-           <version>3.1</version>
-         </plugin>
-         <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-project-info-reports-plugin</artifactId>
            <version>2.7</version>
          </plugin>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -74,28 +74,6 @@
         </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9</version>
-            <configuration>
-              <linksource>true</linksource>
-              <links>
-                <link>http://download.oracle.com/javase/6/docs/api</link>
-                <link>http://download.oracle.com/javaee/6/api</link>
-                <link>http://junit.sourceforge.net/javadoc</link>
-                <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-              </links>
-            </configuration>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>javadoc</report>
-                  <report>test-javadoc</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
             <version>2.3</version>
             <configuration>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -171,6 +171,12 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -107,36 +107,6 @@
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>2.13</version>
       </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jxr-plugin</artifactId>
-          <version>2.3</version>
-          <configuration>
-            <linkJavadoc>true</linkJavadoc>
-          </configuration>
-        </plugin>
        <plugin>
          <groupId>org.codehaus.mojo</groupId>
          <artifactId>jdepend-maven-plugin</artifactId>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -149,11 +149,6 @@
        </plugin>
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>3.1</version>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-project-info-reports-plugin</artifactId>
          <version>2.7</version>
        </plugin>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -169,6 +169,12 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -109,28 +109,6 @@
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
           <configuration>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -149,11 +149,6 @@
        </plugin>
        <plugin>
          <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>3.1</version>
-       </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-project-info-reports-plugin</artifactId>
          <version>2.7</version>
        </plugin>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -171,6 +171,12 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -109,28 +109,6 @@
       </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <linksource>true</linksource>
-            <links>
-              <link>http://download.oracle.com/javase/6/docs/api</link>
-              <link>http://download.oracle.com/javaee/6/api</link>
-              <link>http://junit.sourceforge.net/javadoc</link>
-              <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-            </links>
-          </configuration>
-          <reportSets>
-            <reportSet>
-              <reports>
-                <report>javadoc</report>
-                <report>test-javadoc</report>
-              </reports>
-            </reportSet>
-          </reportSets>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
           <configuration>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -147,11 +147,6 @@
          <artifactId>maven-checkstyle-plugin</artifactId>
          <version>2.9</version>
        </plugin>
-       <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-pmd-plugin</artifactId>
-         <version>2.7.1</version>
-       </plugin>
     </plugins>
   </reporting>
   <profiles>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -80,28 +80,6 @@
         </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9</version>
-            <configuration>
-              <linksource>true</linksource>
-              <links>
-                <link>http://download.oracle.com/javase/6/docs/api</link>
-                <link>http://download.oracle.com/javaee/6/api</link>
-                <link>http://junit.sourceforge.net/javadoc</link>
-                <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
-              </links>
-            </configuration>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>javadoc</report>
-                  <report>test-javadoc</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jxr-plugin</artifactId>
             <version>2.3</version>
             <configuration>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -118,11 +118,6 @@
            <artifactId>maven-checkstyle-plugin</artifactId>
            <version>2.9.1</version>
          </plugin>
-         <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-pmd-plugin</artifactId>
-           <version>3.1</version>
-         </plugin>
       </plugins>
     </reporting>
 

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -123,11 +123,6 @@
            <artifactId>maven-pmd-plugin</artifactId>
            <version>3.1</version>
          </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.3</version>
-        </plugin>
       </plugins>
     </reporting>
 

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -123,6 +123,11 @@
            <artifactId>maven-pmd-plugin</artifactId>
            <version>3.1</version>
          </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>3.0.3</version>
+        </plugin>
       </plugins>
     </reporting>
 

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -62,6 +62,12 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -116,11 +122,6 @@
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-pmd-plugin</artifactId>
            <version>3.1</version>
-         </plugin>
-         <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-project-info-reports-plugin</artifactId>
-           <version>2.7</version>
          </plugin>
       </plugins>
     </reporting>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -102,7 +102,12 @@
             </archive>
           </configuration>
         </plugin>
-
+      <plugin>
+        <!-- In order for the project info plugin report to work with Java 8,
+             you need to declare it in the <build> section, apparently. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <repositories>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -106,29 +106,6 @@
     </plugins>
   </build>
   <repositories>
-    <!-- Disable the use of this old repository to work around Maven bug MNG-4428 -->
-    <repository>
-      <id>java.net</id>
-      <url>https://maven-repository.dev.java.net/nonav/repository</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <!-- And replace it with this -->
-    <repository>
-      <id>java.net1</id>
-      <url>http://download.java.net/maven/1</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-
     <repository>
       <id>jboss</id>
       <url>http://repository.jboss.org</url>


### PR DESCRIPTION
These changes address issue #44 by re-enabling the findbugs reporting plugin for all projects including project originals and archetypes.  The findbugs configuration resides in the top-level "CS410J" pom.xml and is inherited by all projects.  I also moved the configuration for the Javadoc plugin and the PMD plugin to the top level POM.  I also had to add some awkward configuration in order to get the Project Info Report plugin to work with Java 8 code.