### PR TITLE
Issue 43 cobertura

### DIFF
--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -51,6 +51,7 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>

--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>airline</finalName>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -51,6 +51,7 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>apptbook</finalName>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -51,6 +51,7 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>phonebill</finalName>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -64,6 +64,7 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -65,6 +65,13 @@
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>gwt</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
           <linkJavadoc>true</linkJavadoc>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+      </plugin>
       <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -344,10 +349,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jdepend-maven-plugin</artifactId>
         <version>2.0-beta-2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
       </plugin>
       -->
       <plugin>

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/pom.xml
@@ -9,8 +9,9 @@
   <artifactId>airline-gwt-archetype</artifactId>
   <version>Summer2016</version>
   <packaging>maven-archetype</packaging>
+
   <name>airline-gwt-archetype</name>
-  <description>A Maven Archetype for creating a GWT Project for the Airline</description>
+
   <build>
     <extensions>
       <extension>

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,6 +51,14 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>airline</finalName>

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/pom.xml
@@ -9,8 +9,8 @@
   <artifactId>apptbook-gwt-archetype</artifactId>
   <version>Summer2016</version>
   <packaging>maven-archetype</packaging>
+
   <name>apptbook-gwt-archetype</name>
-  <description>A Maven Archetype for creating a GWT Project for the Appointment Book</description>
 
   <build>
     <extensions>

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,6 +51,14 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -9,8 +9,9 @@
   <artifactId>apptbook-web-archetype</artifactId>
   <version>Summer2016</version>
   <packaging>maven-archetype</packaging>
+
   <name>apptbook-web-archetype</name>
-  <description> Maven Archetype for creating a Web/REST Project for the Appointment Book</description>
+
   <build>
     <extensions>
       <extension>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>apptbook</finalName>

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/pom.xml
@@ -9,8 +9,9 @@
   <artifactId>phonebill-gwt-archetype</artifactId>
   <version>Summer2016</version>
   <packaging>maven-archetype</packaging>
+
   <name>phonebill-gwt-archetype</name>
-  <description>A Maven Archetype for creating a GWT Project for the Phone Bill</description>
+
   <build>
     <extensions>
       <extension>

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -51,6 +51,14 @@
       <groupId>com.blueesoteric</groupId>
       <artifactId>gwt-syncproxy</artifactId>
       <version>0.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -9,8 +9,9 @@
   <artifactId>phonebill-web-archetype</artifactId>
   <version>Summer2016</version>
   <packaging>maven-archetype</packaging>
+
   <name>phonebill-web-archetype</name>
-  <description>Maven Archetype for creating a Web/REST Project for the Phone Bill</description>
+
   <build>
     <extensions>
       <extension>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>phonebill</finalName>  <!-- Need finalName to make integration tests work -->

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>airline</finalName>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>apptbook</finalName>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>servlet-api</artifactId>
       <version>3.0-alpha-1</version>
     </dependency>
+    <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
   </dependencies>
   <build>
     <finalName>phonebill</finalName>  <!-- Need finalName to make integration tests work -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -128,6 +128,13 @@
       <version>3.0-alpha-1</version>
     </dependency>
     <dependency>
+      <groupId>net.sourceforge.cobertura</groupId>
+      <artifactId>cobertura-runtime</artifactId>
+      <version>2.1.1</version>
+      <scope>runtime</scope>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>


### PR DESCRIPTION
Address issue #43 by re-enabling the Cobertura Maven plugin.  Cobertura reports are successfully generated for the "original" projects and the archetypes.  However, Cobertura still has problems with Java 8 language syntax.  So, I'm not sure if these changes will last that long.