### PR TITLE
Issue 138 generic type for project classes

### DIFF
--- a/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/Airline.java
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/Airline.java
@@ -1,14 +1,13 @@
 package edu.pdx.cs410J.airlinegwt.client;
 
-import edu.pdx.cs410J.AbstractFlight;
 import edu.pdx.cs410J.AbstractAirline;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class Airline extends AbstractAirline
+public class Airline extends AbstractAirline<Flight>
 {
-  private Collection<AbstractFlight> flights = new ArrayList<AbstractFlight>();
+  private Collection<Flight> flights = new ArrayList<>();
 
   @Override
   public String getName() {
@@ -16,12 +15,12 @@ public class Airline extends AbstractAirline
   }
 
   @Override
-  public void addFlight(AbstractFlight flight) {
+  public void addFlight(Flight flight) {
     this.flights.add(flight);
   }
 
   @Override
-  public Collection getFlights() {
+  public Collection<Flight> getFlights() {
     return this.flights;
   }
 }

--- a/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/Airline.java
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/Airline.java
@@ -10,14 +10,17 @@ public class Airline extends AbstractAirline
 {
   private Collection<AbstractFlight> flights = new ArrayList<AbstractFlight>();
 
+  @Override
   public String getName() {
     return "Air CS410J";
   }
 
+  @Override
   public void addFlight(AbstractFlight flight) {
     this.flights.add(flight);
   }
 
+  @Override
   public Collection getFlights() {
     return this.flights;
   }

--- a/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/AirlineGwt.java
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/src/main/java/edu/pdx/cs410J/airlinegwt/client/AirlineGwt.java
@@ -9,7 +9,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.RootPanel;
-import edu.pdx.cs410J.AbstractFlight;
 
 import java.util.Collection;
 
@@ -55,8 +54,8 @@ public class AirlineGwt implements EntryPoint {
           @Override
           public void onSuccess(Airline airline) {
             StringBuilder sb = new StringBuilder(airline.toString());
-            Collection<AbstractFlight> flights = airline.getFlights();
-            for (AbstractFlight flight : flights) {
+            Collection<Flight> flights = airline.getFlights();
+            for (Flight flight : flights) {
               sb.append(flight);
               sb.append("\n");
             }

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/src/main/java/edu/pdx/cs410J/apptbookgwt/client/AppointmentBook.java
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/src/main/java/edu/pdx/cs410J/apptbookgwt/client/AppointmentBook.java
@@ -1,15 +1,14 @@
 package edu.pdx.cs410J.apptbookgwt.client;
 
-import edu.pdx.cs410J.AbstractAppointment;
 import edu.pdx.cs410J.AbstractAppointmentBook;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class AppointmentBook extends AbstractAppointmentBook
+public class AppointmentBook extends AbstractAppointmentBook<Appointment>
 {
 
-    private Collection<AbstractAppointment> appts = new ArrayList<AbstractAppointment>();
+    private Collection<Appointment> appts = new ArrayList<>();
 
     @Override
     public String getOwnerName()
@@ -18,13 +17,13 @@ public class AppointmentBook extends AbstractAppointmentBook
     }
 
     @Override
-    public Collection getAppointments()
+    public Collection<Appointment> getAppointments()
     {
         return this.appts;
     }
 
     @Override
-    public void addAppointment( AbstractAppointment appt )
+    public void addAppointment( Appointment appt )
     {
         this.appts.add(appt);
     }

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/src/main/java/edu/pdx/cs410J/apptbookgwt/client/AppointmentBookGwt.java
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/src/main/java/edu/pdx/cs410J/apptbookgwt/client/AppointmentBookGwt.java
@@ -54,8 +54,8 @@ public class AppointmentBookGwt implements EntryPoint {
           @Override
           public void onSuccess(AppointmentBook airline) {
             StringBuilder sb = new StringBuilder(airline.toString());
-            Collection<AbstractAppointment> flights = airline.getAppointments();
-            for (AbstractAppointment flight : flights) {
+            Collection<Appointment> flights = airline.getAppointments();
+            for (Appointment flight : flights) {
               sb.append(flight);
               sb.append("\n");
             }

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBill.java
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBill.java
@@ -1,15 +1,14 @@
 package edu.pdx.cs410J.phonebillgwt.client;
 
-import edu.pdx.cs410J.AbstractPhoneCall;
 import edu.pdx.cs410J.AbstractPhoneBill;
 
 import java.lang.Override;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PhoneBill extends AbstractPhoneBill
+public class PhoneBill extends AbstractPhoneBill<PhoneCall>
 {
-  private Collection<AbstractPhoneCall> calls = new ArrayList<AbstractPhoneCall>();
+  private Collection<PhoneCall> calls = new ArrayList<>();
 
   @Override
   public String getCustomer() {
@@ -17,12 +16,12 @@ public class PhoneBill extends AbstractPhoneBill
   }
 
   @Override
-  public void addPhoneCall(AbstractPhoneCall call) {
+  public void addPhoneCall(PhoneCall call) {
     this.calls.add(call);
   }
 
   @Override
-  public Collection getPhoneCalls() {
+  public Collection<PhoneCall> getPhoneCalls() {
     return this.calls;
   }
 }

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBillGwt.java
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBillGwt.java
@@ -9,7 +9,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.RootPanel;
-import edu.pdx.cs410J.AbstractPhoneCall;
 
 import java.util.Collection;
 

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBillGwt.java
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneBillGwt.java
@@ -54,8 +54,8 @@ public class PhoneBillGwt implements EntryPoint {
           @Override
           public void onSuccess(PhoneBill bill) {
             StringBuilder sb = new StringBuilder(bill.toString());
-            Collection<AbstractPhoneCall> calls = bill.getPhoneCalls();
-            for (AbstractPhoneCall call : calls) {
+            Collection<PhoneCall> calls = bill.getPhoneCalls();
+            for (PhoneCall call : calls) {
               sb.append(call);
               sb.append("\n");
             }

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneCall.java
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/src/main/java/edu/pdx/cs410J/phonebillgwt/client/PhoneCall.java
@@ -18,6 +18,7 @@ public class PhoneCall extends AbstractPhoneCall
     return new Date();
   }
 
+  @Override
   public String getStartTimeString() {
     return "START " + getStartTime();
   }
@@ -27,10 +28,12 @@ public class PhoneCall extends AbstractPhoneCall
     return "345-677-2341";
   }
 
+  @Override
   public Date getEndTime() {
     return new Date();
   }
 
+  @Override
   public String getEndTimeString() {
     return "END " + getEndTime();
   }

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/Airline.java
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/Airline.java
@@ -3,25 +3,27 @@
 #set( $symbol_escape = '\' )
 package ${package}.client;
 
-import edu.pdx.cs410J.AbstractFlight;
 import edu.pdx.cs410J.AbstractAirline;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class Airline extends AbstractAirline
+public class Airline extends AbstractAirline<Flight>
 {
-  private Collection<AbstractFlight> flights = new ArrayList<AbstractFlight>();
+  private Collection<Flight> flights = new ArrayList<>();
 
+  @Override
   public String getName() {
     return "Air CS410J";
   }
 
-  public void addFlight(AbstractFlight flight) {
+  @Override
+  public void addFlight(Flight flight) {
     this.flights.add(flight);
   }
 
-  public Collection getFlights() {
+  @Override
+  public Collection<Flight> getFlights() {
     return this.flights;
   }
 }

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AirlineGwt.java
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AirlineGwt.java
@@ -12,7 +12,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.RootPanel;
-import edu.pdx.cs410J.AbstractFlight;
 
 import java.util.Collection;
 
@@ -58,8 +57,8 @@ public class AirlineGwt implements EntryPoint {
           @Override
           public void onSuccess(Airline airline) {
             StringBuilder sb = new StringBuilder(airline.toString());
-            Collection<AbstractFlight> flights = airline.getFlights();
-            for (AbstractFlight flight : flights) {
+            Collection<Flight> flights = airline.getFlights();
+            for (Flight flight : flights) {
               sb.append(flight);
               sb.append("${symbol_escape}n");
             }

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AppointmentBook.java
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AppointmentBook.java
@@ -3,16 +3,15 @@
 #set( $symbol_escape = '\' )
 package ${package}.client;
 
-import edu.pdx.cs410J.AbstractAppointment;
 import edu.pdx.cs410J.AbstractAppointmentBook;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class AppointmentBook extends AbstractAppointmentBook
+public class AppointmentBook extends AbstractAppointmentBook<Appointment>
 {
 
-    private Collection<AbstractAppointment> appts = new ArrayList<AbstractAppointment>();
+    private Collection<Appointment> appts = new ArrayList<>();
 
     @Override
     public String getOwnerName()
@@ -21,13 +20,13 @@ public class AppointmentBook extends AbstractAppointmentBook
     }
 
     @Override
-    public Collection getAppointments()
+    public Collection<Appointment> getAppointments()
     {
         return this.appts;
     }
 
     @Override
-    public void addAppointment( AbstractAppointment appt )
+    public void addAppointment( Appointment appt )
     {
         this.appts.add(appt);
     }

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AppointmentBookGwt.java
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/AppointmentBookGwt.java
@@ -57,8 +57,8 @@ public class AppointmentBookGwt implements EntryPoint {
           @Override
           public void onSuccess(AppointmentBook airline) {
             StringBuilder sb = new StringBuilder(airline.toString());
-            Collection<AbstractAppointment> flights = airline.getAppointments();
-            for (AbstractAppointment flight : flights) {
+            Collection<Appointment> flights = airline.getAppointments();
+            for (Appointment flight : flights) {
               sb.append(flight);
               sb.append("${symbol_escape}n");
             }

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneBill.java
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneBill.java
@@ -3,16 +3,15 @@
 #set( $symbol_escape = '\' )
 package ${package}.client;
 
-import edu.pdx.cs410J.AbstractPhoneCall;
 import edu.pdx.cs410J.AbstractPhoneBill;
 
 import java.lang.Override;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PhoneBill extends AbstractPhoneBill
+public class PhoneBill extends AbstractPhoneBill<PhoneCall>
 {
-  private Collection<AbstractPhoneCall> calls = new ArrayList<AbstractPhoneCall>();
+  private Collection<PhoneCall> calls = new ArrayList<>();
 
   @Override
   public String getCustomer() {
@@ -20,12 +19,12 @@ public class PhoneBill extends AbstractPhoneBill
   }
 
   @Override
-  public void addPhoneCall(AbstractPhoneCall call) {
+  public void addPhoneCall(PhoneCall call) {
     this.calls.add(call);
   }
 
   @Override
-  public Collection getPhoneCalls() {
+  public Collection<PhoneCall> getPhoneCalls() {
     return this.calls;
   }
 }

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneBillGwt.java
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneBillGwt.java
@@ -12,7 +12,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.RootPanel;
-import edu.pdx.cs410J.AbstractPhoneCall;
 
 import java.util.Collection;
 
@@ -57,8 +56,8 @@ public class PhoneBillGwt implements EntryPoint {
           @Override
           public void onSuccess(PhoneBill bill) {
             StringBuilder sb = new StringBuilder(bill.toString());
-            Collection<AbstractPhoneCall> calls = bill.getPhoneCalls();
-            for (AbstractPhoneCall call : calls) {
+            Collection<PhoneCall> calls = bill.getPhoneCalls();
+            for (PhoneCall call : calls) {
               sb.append(call);
               sb.append("${symbol_escape}n");
             }

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneCall.java
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/src/main/java/client/PhoneCall.java
@@ -21,6 +21,7 @@ public class PhoneCall extends AbstractPhoneCall
     return new Date();
   }
 
+  @Override
   public String getStartTimeString() {
     return "START " + getStartTime();
   }
@@ -30,10 +31,12 @@ public class PhoneCall extends AbstractPhoneCall
     return "345-677-2341";
   }
 
+  @Override
   public Date getEndTime() {
     return new Date();
   }
 
+  @Override
   public String getEndTimeString() {
     return "END " + getEndTime();
   }

--- a/projects-parent/originals-parent/student/src/main/java/edu/pdx/cs410J/student/Student.java
+++ b/projects-parent/originals-parent/student/src/main/java/edu/pdx/cs410J/student/Student.java
@@ -22,7 +22,7 @@ public class Student extends Human {
    * @param gender                                                                  
    *        The student's gender ("male" or "female", case insensitive)             
    */                                                                               
-  public Student(String name, ArrayList classes, double gpa, String gender) {
+  public Student(String name, ArrayList<String> classes, double gpa, String gender) {
     super(name);
   }
 

--- a/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
+++ b/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
@@ -18,7 +18,7 @@ public class StudentTest
   @Test
   public void studentNamedPatIsNamedPat() {
     String name = "Pat";
-    Student pat = new Student(name, new ArrayList(), 0.0, "Doesn't matter");
+    Student pat = new Student(name, new ArrayList<>(), 0.0, "Doesn't matter");
     assertThat(pat.getName(), equalTo(name));
   }
 

--- a/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractAirline.java
+++ b/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractAirline.java
@@ -7,7 +7,7 @@ import java.util.Collection;
  * This class represents an airline.  Each airline has a name and
  * consists of multiple flights.
  */
-public abstract class AbstractAirline implements Serializable
+public abstract class AbstractAirline<T extends AbstractFlight> implements Serializable
 {
 
   /**
@@ -18,12 +18,12 @@ public abstract class AbstractAirline implements Serializable
   /**
    * Adds a flight to this airline.
    */
-  public abstract void addFlight(AbstractFlight flight);
+  public abstract void addFlight(T flight);
 
   /**
    * Returns all of this airline's flights.
    */
-  public abstract Collection getFlights();
+  public abstract Collection<T> getFlights();
 
   /**
    * Returns a brief textual description of this airline.

--- a/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractAppointmentBook.java
+++ b/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractAppointmentBook.java
@@ -9,7 +9,7 @@ import java.util.Collection;
  *
  * @author David Whitlock
  */
-public abstract class AbstractAppointmentBook implements Serializable {
+public abstract class AbstractAppointmentBook<T extends AbstractAppointment> implements Serializable {
 
   /**
    * Returns the name of the owner of this appointment book.
@@ -20,12 +20,12 @@ public abstract class AbstractAppointmentBook implements Serializable {
    * Returns all of the appointments in this appointment book as a
    * collection of {@link AbstractAppointment}s.
    */
-  public abstract Collection getAppointments();
+  public abstract Collection<T> getAppointments();
 
   /**
    * Adds an appointment to this appointment book
    */
-  public abstract void addAppointment(AbstractAppointment appt);
+  public abstract void addAppointment(T appt);
 
   /**
    * Returns a brief textual description of this appointment book

--- a/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractPhoneBill.java
+++ b/projects-parent/projects/src/main/java/edu/pdx/cs410J/AbstractPhoneBill.java
@@ -9,7 +9,7 @@ import java.util.Collection;
  *
  * @author David Whitlock
  */
-public abstract class AbstractPhoneBill implements Serializable {
+public abstract class AbstractPhoneBill<T extends AbstractPhoneCall> implements Serializable {
 
   /**
    * Returns the name of the customer whose phone bill this is
@@ -19,13 +19,13 @@ public abstract class AbstractPhoneBill implements Serializable {
   /**
    * Adds a phone call to this phone bill
    */
-  public abstract void addPhoneCall(AbstractPhoneCall call);
+  public abstract void addPhoneCall(T call);
 
   /**
    * Returns all of the phone calls (as instances of {@link
    * AbstractPhoneCall}) in this phone bill
    */
-  public abstract Collection getPhoneCalls();
+  public abstract Collection<T> getPhoneCalls();
 
   /**
    * Returns a brief textual description of this phone bill


### PR DESCRIPTION
Add a generic type to abstract project classes like AbstractAirline so that the subclasses that students implement can use the concrete type and have to do less type casting.  This addresses issue #138.