### PR TITLE
Issue 28 update archetype plugins

### DIFF
--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -109,7 +109,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/gwt-parent/familygwt/pom.xml
+++ b/gwt-parent/familygwt/pom.xml
@@ -66,7 +66,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>

--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -118,7 +118,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>

--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -114,7 +114,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -119,7 +119,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -115,7 +115,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -118,7 +118,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector>
             <port>${jetty.http.port}</port>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -114,7 +114,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jetty</groupId>

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -181,7 +181,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
       </plugin>
       <plugin>
         <!-- In order for the project info plugin report to work with Java 8,

--- a/gwt-parent/gwt/pom.xml
+++ b/gwt-parent/gwt/pom.xml
@@ -124,7 +124,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>

--- a/gwt-parent/pom.xml
+++ b/gwt-parent/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>build-helper-maven-plugin</artifactId>
-              <version>1.8</version>
+              <version>1.10</version>
               <executions>
                 <execution>
                   <id>add-it-sources</id>

--- a/gwt-parent/pom.xml
+++ b/gwt-parent/pom.xml
@@ -111,6 +111,11 @@
                 </execution>
               </executions>
             </plugin>
+            <plugin>
+              <groupId>org.eclipse.jetty</groupId>
+              <artifactId>jetty-maven-plugin</artifactId>
+              <version>9.3.6.v20151106</version>
+            </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,11 @@
           <artifactId>maven-shade-plugin</artifactId>
           <version>2.4.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-maven-plugin</artifactId>
+          <version>9.3.6.v20151106</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,26 @@
               </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.10</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
          <dependency>
            <groupId>org.apache.maven.wagon</groupId>
            <artifactId>wagon-ssh-external</artifactId>
-           <version>1.0-beta-7</version>
+           <version>2.10</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -190,9 +190,14 @@
     <pluginManagement>
       <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.7</version>
+        <version>1.10</version>
         <executions>
           <execution>
             <id>add-it-source</id>
@@ -336,7 +341,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.2</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -382,6 +387,8 @@
             <link>http://www.gwtproject.org/javadoc/latest</link>
             <link>http://web.cecs.pdx.edu/~whitlock/docs</link>
           </links>
+          <detectJavaApiLink/>
+          <detectLinks/>
         </configuration>
         <reportSets>
           <reportSet>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,20 @@
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.1</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-updates-report</report>
+              <report>plugin-updates-report</report>
+              <report>property-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
       <!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
@@ -255,7 +255,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.18.1</version>
+          <version>2.19</version>
           <configuration>
             <testSourceDirectory>src/it/java</testSourceDirectory>
             <testClassesDirectory>${project.build.directory}/it-classes</testClassesDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,11 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.3</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.4.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080" />
           <stopKey>stop-key</stopKey>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -168,7 +168,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080"/>
           <stopKey>stop-key</stopKey>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -80,7 +80,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector port="8080" />
           <stopKey>stop-key</stopKey>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -166,7 +166,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -80,7 +80,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -168,7 +168,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.2.10.v20150310</version>
         <configuration>
           <httpConnector>
             <port>${jetty.http.port}</port>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -80,7 +80,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -44,7 +44,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -27,11 +27,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.13</version>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -20,11 +20,6 @@
     <finalName>web</finalName>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -34,7 +34,6 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.0.M2</version>
         <configuration>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopPort>9999</stopPort>


### PR DESCRIPTION
Updated the versions of plugins used by the project archetypes.  Along the way, I centralized a lot of the version configuration in parent POMs so that it can be updated in the future in one place.  This addresses issue #28.  I also enabled the dependency update reports for all projects.  However, those reports seem to suffer from the same problem that I saw in issue #140.  So, I'll have to do some more updating in the future.  No big surprise there.