### PR TITLE
Issue 178 select next poa after save grade

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/DisplayNextPOAEvent.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/DisplayNextPOAEvent.java
@@ -1,0 +1,4 @@
+package edu.pdx.cs410J.grader.poa;
+
+public class DisplayNextPOAEvent {
+}

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POAGradePresenter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POAGradePresenter.java
@@ -45,7 +45,7 @@ public class POAGradePresenter {
     this.bus.post(recordGrade);
     this.view.setScoreHasBeenRecorded(true);
 
-    DisplayNextPOAEvent displayNextPOA = new DisplayNextPOAEvent();
+    SelectNextPOAEvent displayNextPOA = new SelectNextPOAEvent();
     this.bus.post(displayNextPOA);
   }
 

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POAGradePresenter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POAGradePresenter.java
@@ -33,17 +33,20 @@ public class POAGradePresenter {
 
     this.view.addIsLateHandler(POAGradePresenter.this::setIsLate);
     this.view.addScoreValueHandler(this::setScoreValue);
-    this.view.addRecordGradeHandler(this::publishScoreToMessageBus);
+    this.view.addRecordGradeHandler(this::publishScoreToMessageBusAndDisplayNextPOA);
   }
 
-  private void publishScoreToMessageBus() {
+  private void publishScoreToMessageBusAndDisplayNextPOA() {
     if (this.score == null) {
       throw new IllegalStateException("No score specified");
     }
 
-    RecordGradeEvent event = new RecordGradeEvent(this.score, this.student, this.assignment, this.isLate);
-    this.bus.post(event);
+    RecordGradeEvent recordGrade = new RecordGradeEvent(this.score, this.student, this.assignment, this.isLate);
+    this.bus.post(recordGrade);
     this.view.setScoreHasBeenRecorded(true);
+
+    DisplayNextPOAEvent displayNextPOA = new DisplayNextPOAEvent();
+    this.bus.post(displayNextPOA);
   }
 
   @Subscribe

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionPresenter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionPresenter.java
@@ -30,6 +30,6 @@ public class POASubmissionPresenter {
   }
 
   static String formatSubmissionTime(LocalDateTime submitTime) {
-    return submitTime.format(DateTimeFormatter.ofPattern("M/d/yyyy h:mm a"));
+    return submitTime.format(DateTimeFormatter.ofPattern("E M/d/yyyy h:mm a"));
   }
 }

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenter.java
@@ -49,12 +49,9 @@ public class POASubmissionsPresenter {
   public void displayNextPOA(DisplayNextPOAEvent event) {
     int nextIndex = this.selectedSubmissionIndex + 1;
 
-    if (nextIndex >= this.submissions.size()) {
-      throw new IllegalStateException("Can't select submission " + nextIndex +
-        " because there are only " + this.submissions.size() + " submissions");
+    if (nextIndex < this.submissions.size()) {
+      view.selectPOASubmission(nextIndex);
+      poaSubmissionSelected(nextIndex);
     }
-
-    view.selectPOASubmission(nextIndex);
-    poaSubmissionSelected(nextIndex);
   }
 }

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenter.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenter.java
@@ -46,7 +46,7 @@ public class POASubmissionsPresenter {
   }
 
   @Subscribe
-  public void displayNextPOA(DisplayNextPOAEvent event) {
+  public void selectNextPOA(SelectNextPOAEvent event) {
     int nextIndex = this.selectedSubmissionIndex + 1;
 
     if (nextIndex < this.submissions.size()) {

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsView.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsView.java
@@ -11,6 +11,8 @@ public interface POASubmissionsView {
 
   void addDownloadSubmissionsListener(DownloadSubmissionsListener listener);
 
+  void selectPOASubmission(int index);
+
   interface POASubmissionSelectedListener {
     public void submissionSelected(int index);
   }

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/SelectNextPOAEvent.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/SelectNextPOAEvent.java
@@ -1,4 +1,4 @@
 package edu.pdx.cs410J.grader.poa;
 
-public class DisplayNextPOAEvent {
+public class SelectNextPOAEvent {
 }

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/ui/POASubmissionsPanel.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/ui/POASubmissionsPanel.java
@@ -51,7 +51,7 @@ public class POASubmissionsPanel extends JPanel implements POASubmissionsView {
 
   @Override
   public void selectPOASubmission(int index) {
-    throw new UnsupportedOperationException("This method is not implemented yet");
+    this.submissions.setSelectedIndex(index);
   }
 
   private boolean isFinalEventInUserSelection(ListSelectionEvent e) {

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/ui/POASubmissionsPanel.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/ui/POASubmissionsPanel.java
@@ -49,6 +49,11 @@ public class POASubmissionsPanel extends JPanel implements POASubmissionsView {
     this.downloadSubmissions.addActionListener(e -> listener.downloadSubmissions());
   }
 
+  @Override
+  public void selectPOASubmission(int index) {
+    throw new UnsupportedOperationException("This method is not implemented yet");
+  }
+
   private boolean isFinalEventInUserSelection(ListSelectionEvent e) {
     return !e.getValueIsAdjusting();
   }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/poa/POAGradePresenterTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/poa/POAGradePresenterTest.java
@@ -379,6 +379,28 @@ public class POAGradePresenterTest extends POASubmissionTestCase {
     verify(this.view).setScoreHasBeenRecorded(true);
   }
 
+  @Test
+  public void recordingGradeInViewPublishesDisplayNextPOAMessage() {
+    ArgumentCaptor<ScoreValueHandler> scoreHandler = ArgumentCaptor.forClass(ScoreValueHandler.class);
+    verify(this.view).addScoreValueHandler(scoreHandler.capture());
+
+    ArgumentCaptor<RecordGradeHandler> recordGrade = ArgumentCaptor.forClass(RecordGradeHandler.class);
+    verify(this.view).addRecordGradeHandler(recordGrade.capture());
+
+    DisplayNextPOAEventHandler eventHandler = mock(DisplayNextPOAEventHandler.class);
+    this.bus.register(eventHandler);
+
+    this.assignment.setDueDate(LocalDateTime.now().minusDays(5));
+    postEventsToBus();
+
+    double score = 0.75;
+    scoreHandler.getValue().scoreValue(formatTotalPoints(score));
+    recordGrade.getValue().recordGrade();
+
+    ArgumentCaptor<DisplayNextPOAEvent> eventCaptor = ArgumentCaptor.forClass(DisplayNextPOAEvent.class);
+    verify(eventHandler).handleDisplayNextPOAEvent(eventCaptor.capture());
+  }
+
   private interface RecordGradeEventHandler {
     @Subscribe
     void handleRecordGradeEvent(RecordGradeEvent event);
@@ -427,5 +449,10 @@ public class POAGradePresenterTest extends POASubmissionTestCase {
 
     verify(this.view, times(5)).setScore("");
     verifyIsLate(4, false);
+  }
+
+  private interface DisplayNextPOAEventHandler {
+    @Subscribe
+    public void handleDisplayNextPOAEvent(DisplayNextPOAEvent event);
   }
 }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/poa/POAGradePresenterTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/poa/POAGradePresenterTest.java
@@ -397,7 +397,7 @@ public class POAGradePresenterTest extends POASubmissionTestCase {
     scoreHandler.getValue().scoreValue(formatTotalPoints(score));
     recordGrade.getValue().recordGrade();
 
-    ArgumentCaptor<DisplayNextPOAEvent> eventCaptor = ArgumentCaptor.forClass(DisplayNextPOAEvent.class);
+    ArgumentCaptor<SelectNextPOAEvent> eventCaptor = ArgumentCaptor.forClass(SelectNextPOAEvent.class);
     verify(eventHandler).handleDisplayNextPOAEvent(eventCaptor.capture());
   }
 
@@ -453,6 +453,6 @@ public class POAGradePresenterTest extends POASubmissionTestCase {
 
   private interface DisplayNextPOAEventHandler {
     @Subscribe
-    public void handleDisplayNextPOAEvent(DisplayNextPOAEvent event);
+    public void handleDisplayNextPOAEvent(SelectNextPOAEvent event);
   }
 }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
@@ -101,7 +101,7 @@ public class POASubmissionsPresenterTest extends POASubmissionTestCase {
     bus.post(submission2);
 
     // When a DisplayNextPOAEvent is posted
-    bus.post(new DisplayNextPOAEvent());
+    bus.post(new SelectNextPOAEvent());
 
     // Then the View is updated
     verify(view).selectPOASubmission(1);
@@ -132,7 +132,7 @@ public class POASubmissionsPresenterTest extends POASubmissionTestCase {
     bus.post(submission1);
 
     // When a DisplayNextPOAEvent is posted
-    bus.post(new DisplayNextPOAEvent());
+    bus.post(new SelectNextPOAEvent());
 
     // Then nothing happens
     verify(view, times(0)).selectPOASubmission(anyInt());

--- a/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
@@ -81,6 +81,40 @@ public class POASubmissionsPresenterTest extends POASubmissionTestCase {
     verifyNoMoreInteractions(handler);
   }
 
+  @Test
+  public void displayNextPOAEventDisplaysNextPOA() {
+    // Given that there are two POA submissions
+    String subject1 = "POA for Project 1";
+    String subject2 = "POA for Project 2";
+    String submitter = "Test Student";
+    LocalDateTime submitTime = LocalDateTime.now();
+
+    POASubmissionSelectedHandler handler = mock(POASubmissionSelectedHandler.class);
+    bus.register(handler);
+
+    ArgumentCaptor<POASubmissionsView.POASubmissionSelectedListener> listener = ArgumentCaptor.forClass(POASubmissionsView.POASubmissionSelectedListener.class);
+    verify(view).addSubmissionSelectedListener(listener.capture());
+
+    POASubmission submission1 = createPOASubmission(subject1, submitter, submitTime);
+    bus.post(submission1);
+    POASubmission submission2 = createPOASubmission(subject2, submitter, submitTime);
+    bus.post(submission2);
+
+    // When a DisplayNextPOAEvent is posted
+    bus.post(new DisplayNextPOAEvent());
+
+    // Then the View is updated
+    verify(view).selectPOASubmission(1);
+
+    // Then a POASubmissionSelected event for the second submission is fired
+
+    ArgumentCaptor<POASubmissionSelected> eventCaptor = ArgumentCaptor.forClass(POASubmissionSelected.class);
+    verify(handler).handle(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getSubmission(), equalTo(submission2));
+
+    verifyNoMoreInteractions(handler);
+  }
+
   private interface POASubmissionSelectedHandler {
     @Subscribe
     public void handle(POASubmissionSelected selected);

--- a/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/poa/POASubmissionsPresenterTest.java
@@ -115,6 +115,31 @@ public class POASubmissionsPresenterTest extends POASubmissionTestCase {
     verifyNoMoreInteractions(handler);
   }
 
+  @Test
+  public void displayingNextPOAAtEndOfSubmissionListDoesNothing() {
+    // Given that there is only one POA Submission
+    String subject1 = "POA for Project 1";
+    String submitter = "Test Student";
+    LocalDateTime submitTime = LocalDateTime.now();
+
+    POASubmissionSelectedHandler handler = mock(POASubmissionSelectedHandler.class);
+    bus.register(handler);
+
+    ArgumentCaptor<POASubmissionsView.POASubmissionSelectedListener> listener = ArgumentCaptor.forClass(POASubmissionsView.POASubmissionSelectedListener.class);
+    verify(view).addSubmissionSelectedListener(listener.capture());
+
+    POASubmission submission1 = createPOASubmission(subject1, submitter, submitTime);
+    bus.post(submission1);
+
+    // When a DisplayNextPOAEvent is posted
+    bus.post(new DisplayNextPOAEvent());
+
+    // Then nothing happens
+    verify(view, times(0)).selectPOASubmission(anyInt());
+
+    verifyNoMoreInteractions(handler);
+  }
+
   private interface POASubmissionSelectedHandler {
     @Subscribe
     public void handle(POASubmissionSelected selected);


### PR DESCRIPTION
Address issue #178 by selecting the next POA submission after the grade has been saved.  This saves me a bunch of clicks.  I also added the abbreviated day to the submission's timestamp so it's easier for me to confirm how late the submission was.