### PR TITLE
Issue 177 rename get out and get err

### DIFF
--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
@@ -29,7 +29,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -35,14 +35,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -50,8 +50,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -62,17 +62,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
@@ -29,7 +29,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -35,14 +35,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -50,8 +50,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -62,17 +62,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
@@ -29,7 +29,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -34,14 +34,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -49,8 +49,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -61,17 +61,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/it/java/StudentIT.java
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/it/java/StudentIT.java
@@ -25,7 +25,7 @@ public class StudentIT extends InvokeMainTestCase {
   @Test
   public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project4IT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project4IT.java
@@ -32,14 +32,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -47,8 +47,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -59,17 +59,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/originals-parent/airline/src/it/java/edu/pdx/cs410J/airline/Project1IT.java
+++ b/projects-parent/originals-parent/airline/src/it/java/edu/pdx/cs410J/airline/Project1IT.java
@@ -26,7 +26,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
@@ -32,14 +32,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -47,8 +47,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -59,17 +59,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/originals-parent/apptbook/src/it/java/edu/pdx/cs410J/apptbook/Project1IT.java
+++ b/projects-parent/originals-parent/apptbook/src/it/java/edu/pdx/cs410J/apptbook/Project1IT.java
@@ -26,7 +26,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
@@ -31,14 +31,14 @@ public class Project4IT extends InvokeMainTestCase {
     public void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
-        assertThat(result.getErr(), containsString(Project4.MISSING_ARGS));
+        assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
     public void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
     }
 
@@ -46,8 +46,8 @@ public class Project4IT extends InvokeMainTestCase {
     public void test3NoValues() {
         String key = "KEY";
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(0)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, null)));
     }
@@ -58,17 +58,17 @@ public class Project4IT extends InvokeMainTestCase {
         String value = "VALUE";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, key, value );
-        assertThat(result.getErr(), result.getExitCode(), equalTo(0));
-        String out = result.getOut();
+        assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
+        String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.mappedKeyValue(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, key );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
-        out = result.getOut();
+        out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.getMappingCount(1)));
         assertThat(out, out, containsString(Messages.formatKeyValuePair(key, value)));
     }

--- a/projects-parent/originals-parent/phonebill/src/it/java/edu/pdx/cs410J/phonebill/Project1IT.java
+++ b/projects-parent/originals-parent/phonebill/src/it/java/edu/pdx/cs410J/phonebill/Project1IT.java
@@ -26,7 +26,7 @@ public class Project1IT extends InvokeMainTestCase {
   public void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 }

--- a/projects-parent/originals-parent/student/src/it/java/edu/pdx/cs410J/student/StudentIT.java
+++ b/projects-parent/originals-parent/student/src/it/java/edu/pdx/cs410J/student/StudentIT.java
@@ -22,7 +22,7 @@ public class StudentIT extends InvokeMainTestCase {
   @Test
   public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
-    assertThat(result.getErr(), containsString("Missing command line arguments"));
+    assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
 
 

--- a/projects-parent/projects/src/it/java/edu/pdx/cs410J/InvokeMainIT.java
+++ b/projects-parent/projects/src/it/java/edu/pdx/cs410J/InvokeMainIT.java
@@ -40,20 +40,20 @@ public class InvokeMainIT extends InvokeMainTestCase {
     @Test
     public void testStandardOutput() {
         MainMethodResult result = invokeMain( WriteArgsToStandardOut.class, "1", "2", "3", "4", "5" );
-        assertEquals( "12345", result.getOut() );
+        assertEquals( "12345", result.getTextWrittenToStandardOut() );
     }
 
     @Test
     public void testStandardError() {
         MainMethodResult result = invokeMain( WriteArgsToStandardErr.class, "1", "2", "3", "4", "5" );
-        assertEquals( "12345", result.getErr() );
+        assertEquals( "12345", result.getTextWrittenToStandardError() );
     }
 
   @Test
   public void codeAfterSystemExitIsNotExecuted() {
     MainMethodResult result = invokeMain(CodeAfterSystemExit.class);
     assertThat(result.getExitCode(), equalTo(1));
-    assertThat(result.getOut(), equalTo(""));
+    assertThat(result.getTextWrittenToStandardOut(), equalTo(""));
   }
 
     private static class NoExitCode

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
@@ -125,7 +125,7 @@ public abstract class InvokeMainTestCase
          * Returns the data written to standard out
          * @return the data written to standard out
          */
-        public String getOut()
+        public String getTextWrittenToStandardOut()
         {
             return out;
         }
@@ -134,7 +134,7 @@ public abstract class InvokeMainTestCase
          * Returns the data written to standard err
          * @return the data written to standard err
          */
-        public String getErr()
+        public String getTextWrittenToStandardError()
         {
             return err;
         }


### PR DESCRIPTION
Address issue #177 by renaming the getOut() and getErr() methods in `MainMethodResult`.