### PR TITLE
Issue 175 javadoc for all visibility

### DIFF
--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -198,6 +198,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/airline-gwt/pom.xml
@@ -184,6 +184,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -185,6 +185,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/apptbook-gwt/pom.xml
@@ -199,6 +199,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -198,6 +198,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
+++ b/gwt-parent/gwt-originals-parent/phonebill-gwt/pom.xml
@@ -184,6 +184,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -127,6 +127,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -141,6 +141,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "The main class for the CS410J airline Project"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -197,6 +197,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -183,6 +183,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/airline-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A basic GWT class that makes sure that we can send an airline back"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -188,6 +188,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -202,6 +202,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A helper class for accessing the rest client."
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -127,6 +127,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,13 @@
+package projects.javadoc
+
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "The main class for the CS410J appointment book Project"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -211,6 +211,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -197,6 +197,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/apptbook-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A basic GWT class that makes sure that we can send an appointment book"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -188,6 +188,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -202,6 +202,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A helper class for accessing the rest client"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -136,6 +136,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -122,6 +122,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "The main class for the CS410J Phone Bill Project"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -198,6 +198,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/main/resources/archetype-resources/pom.xml
@@ -184,6 +184,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/phonebill-gwt-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A basic GWT class that makes sure that we can send an Phone Bill back"
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -189,6 +189,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -203,6 +203,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "A helper class for accessing the rest client."
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -117,4 +117,33 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9</version>
+            <configuration>
+              <doclet>edu.pdx.cs410J.grader.APIDocumentationDoclet</doclet>
+              <docletArtifact>
+                <groupId>edu.pdx.cs410J</groupId>
+                <artifactId>grader</artifactId>
+                <version>Summer2017</version>
+              </docletArtifact>
+              <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/archetype.properties
+++ b/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/archetype.properties
@@ -1,0 +1,5 @@
+package=it.pkg.javadoc
+version=0.1-SNAPSHOT
+groupId=javadoc.archetype.it
+artifactId=javadoc
+grader=true

--- a/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/goal.txt
+++ b/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/goal.txt
@@ -1,0 +1,1 @@
+javadoc:javadoc

--- a/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/verify.groovy
+++ b/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/javadoc/verify.groovy
@@ -1,0 +1,11 @@
+File buildLog = new File(basedir, "project/javadoc/build.log");
+if (!buildLog.isFile()) {
+  throw new FileNotFoundException("Couldn't find build log: " + buildLog)
+}
+
+String logText = buildLog.text
+
+def expectedJavaDoc = "This class is represents a <code>Student</code>."
+if (!logText.contains(expectedJavaDoc)) {
+  throw new IllegalStateException("Didn't find expected JavaDoc: " + expectedJavaDoc)
+}

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -189,6 +189,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -203,6 +203,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -126,6 +126,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -140,6 +140,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -201,6 +201,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -187,6 +187,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -126,6 +126,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -201,6 +201,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -187,6 +187,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -135,6 +135,7 @@
                 <version>Summer2017</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
             </configuration>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -121,6 +121,9 @@
   <profiles>
     <profile>
       <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -116,4 +116,33 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>grader</id>
+      <activation>
+        <activeByDefault>${grader}</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9</version>
+            <configuration>
+              <doclet>edu.pdx.cs410J.grader.APIDocumentationDoclet</doclet>
+              <docletArtifact>
+                <groupId>edu.pdx.cs410J</groupId>
+                <artifactId>grader</artifactId>
+                <version>Summer2017</version>
+              </docletArtifact>
+              <useStandardDocletOptions>false</useStandardDocletOptions>
+              <show>private</show>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Address issue #175 so that when generating the Grader javadocs for projects, include class members with all visibilities.   Also, add integration tests that generate and verify the Grader javadoc.