### PR TITLE
Address issues #203 by setting the IP address for localhost for SMTP

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/EmailSender.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/EmailSender.java
@@ -30,6 +30,7 @@ public class EmailSender {
     Properties props = new Properties();
     props.put("mail.smtp.host", serverName);
     props.put("mail.smtp.port", emailServerPort);
+    props.put("mail.smtp.localhost", "127.0.0.1");
     Session session = Session.getDefaultInstance(props, null);
     session.setDebug(debug);
     return session;


### PR DESCRIPTION
On some Linux systems you need to explicitly set the IP address for localhost in order for sendmail to work.