### PR TITLE
Remove rmi stub classes

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -56,6 +56,13 @@
       <artifactId>groovy-all</artifactId>
       <version>${groovy.version}</version>
     </dependency>
+    <dependency>
+      <groupId>edu.pdx.cs410J</groupId>
+      <artifactId>projects</artifactId>
+      <version>Summer2016</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,26 +60,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>rmic-maven-plugin</artifactId>
-        <version>1.2.1</version>
-        <executions>
-          <execution>
-            <id>rmic-process-classes</id>
-            <goals>
-              <goal>rmic</goal>
-            </goals>
-            <configuration>
-              <verbose>true</verbose>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <includes>
-                <include>edu/pdx/cs410J/rmi/*Impl.class</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <version>1.5</version>

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
@@ -1,7 +1,8 @@
 package edu.pdx.cs410J.rmi;
 
-import java.net.*;
-import java.rmi.*;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
 
 /**
  * This program contacts the remote movie database and creates a new
@@ -15,27 +16,12 @@ public class CreateMovie {
     String title = args[2];
     int year = Integer.parseInt(args[3]);
 
-    // Install an RMISecurityManager, if there is not a
-    // SecurityManager already installed
-    if (System.getSecurityManager() == null) {
-      System.setSecurityManager(new RMISecurityManager());
-    }
-
-    String name = "//" + host + ":" + port + "/MovieDatabase";
-
     try {
-      MovieDatabase db = 
-        (MovieDatabase) Naming.lookup(name);
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
       long id = db.createMovie(title, year);
       System.out.println("Created movie " + id);
 
-    } catch (RemoteException ex) {
-      ex.printStackTrace(System.err);
-
-    } catch (NotBoundException ex) {
-      ex.printStackTrace(System.err);
-
-    } catch (MalformedURLException ex) {
+    } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
     }
 

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
@@ -17,7 +17,7 @@ public class CreateMovie {
     int year = Integer.parseInt(args[3]);
 
     try {
-      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup(MovieDatabase.RMI_OBJECT_NAME);
       long id = db.createMovie(title, year);
       System.out.println("Created movie " + id);
       System.exit(0);

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/CreateMovie.java
@@ -20,9 +20,11 @@ public class CreateMovie {
       MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
       long id = db.createMovie(title, year);
       System.out.println("Created movie " + id);
+      System.exit(0);
 
     } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
+      System.exit(1);
     }
 
   }

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/GetFilmography.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/GetFilmography.java
@@ -1,10 +1,8 @@
 package edu.pdx.cs410J.rmi;
 
-import java.net.MalformedURLException;
-import java.rmi.Naming;
 import java.rmi.NotBoundException;
-import java.rmi.RMISecurityManager;
 import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
 
 /**
  * This program searches the remote movie database for all of the
@@ -17,20 +15,11 @@ public class GetFilmography {
     int port = Integer.parseInt(args[1]);
     Long actor = Long.parseLong(args[2]);
 
-    // Install an RMISecurityManager, if there is not a
-    // SecurityManager already installed
-    if (System.getSecurityManager() == null) {
-      System.setSecurityManager(new RMISecurityManager());
-    }
-
-    String name = "rmi://" + host + ":" + port + "/MovieDatabase";
-
     try {
-      MovieDatabase db = 
-        (MovieDatabase) Naming.lookup(name);
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
       db.getFilmography(actor).forEach(System.out::println);
 
-    } catch (RemoteException | NotBoundException | MalformedURLException ex) {
+    } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
     }
 

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/GetFilmography.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/GetFilmography.java
@@ -16,7 +16,7 @@ public class GetFilmography {
     Long actor = Long.parseLong(args[2]);
 
     try {
-      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup(MovieDatabase.RMI_OBJECT_NAME);
       db.getFilmography(actor).forEach(System.out::println);
 
     } catch (RemoteException | NotBoundException ex) {

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/GetMoviesInYear.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/GetMoviesInYear.java
@@ -18,7 +18,7 @@ public class GetMoviesInYear {
     int port = Integer.parseInt(args[1]);
     final int year = Integer.parseInt(args[2]);
     try {
-      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup(MovieDatabase.RMI_OBJECT_NAME);
 
       Query query = movie -> movie.getYear() == year;
 

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/GetMoviesInYear.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/GetMoviesInYear.java
@@ -1,8 +1,9 @@
 package edu.pdx.cs410J.rmi;
 
-import java.net.*;
-import java.rmi.*;
-import java.util.*;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.util.Comparator;
 
 /**
  * This program queries the remote movie database an prints out the
@@ -16,18 +17,8 @@ public class GetMoviesInYear {
     String host = args[0];
     int port = Integer.parseInt(args[1]);
     final int year = Integer.parseInt(args[2]);
-
-    // Install an RMISecurityManager, if there is not a
-    // SecurityManager already installed
-    if (System.getSecurityManager() == null) {
-      System.setSecurityManager(new RMISecurityManager());
-    }
-
-    String name = "rmi://" + host + ":" + port + "/MovieDatabase";
-
     try {
-      MovieDatabase db = 
-        (MovieDatabase) Naming.lookup(name);
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup("/MovieDatabase");
 
       Query query = movie -> movie.getYear() == year;
 
@@ -35,7 +26,7 @@ public class GetMoviesInYear {
 
       db.executeQuery(query, sorter).forEach(System.out::println);
 
-    } catch (RemoteException | NotBoundException | MalformedURLException ex) {
+    } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
     }
 

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabase.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabase.java
@@ -9,6 +9,8 @@ import java.util.*;
  */
 public interface MovieDatabase extends Remote {
 
+  String RMI_OBJECT_NAME = "/MovieDatabase";
+
   /**
    * Creates a new <code>Movie</code> object on the server.  It
    * returns the id of the movie that was created.

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabaseImpl.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabaseImpl.java
@@ -141,7 +141,7 @@ public class MovieDatabaseImpl implements MovieDatabase {
 
   @Override
   public Collection<Movie> getMovies() {
-    return this.movies.values();
+    return new HashSet<>(this.movies.values());
   }
 
   @Override

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabaseImpl.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/MovieDatabaseImpl.java
@@ -69,8 +69,7 @@ public class MovieDatabaseImpl implements MovieDatabase {
    *         character is already played by someone else
    */
   @Override
-  public void noteCharacter(long movieId, String character, long actorId)
-    throws RemoteException {
+  public void noteCharacter(long movieId, String character, long actorId) {
     Movie movie = getExistingMovie(movieId);
     movie.addCharacter(character, actorId);
   }
@@ -160,10 +159,9 @@ public class MovieDatabaseImpl implements MovieDatabase {
     int port = Integer.parseInt(args[0]);
 
     try {
-      String name = "/MovieDatabase";
       MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(new MovieDatabaseImpl(), port);
       Registry registry = LocateRegistry.createRegistry(port);
-      registry.bind(name, database);
+      registry.bind(MovieDatabase.RMI_OBJECT_NAME, database);
 
     } catch (RemoteException | AlreadyBoundException ex) {
       ex.printStackTrace(System.err);

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/NoteCharacter.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/NoteCharacter.java
@@ -1,9 +1,10 @@
 package edu.pdx.cs410J.rmi;
 
 import java.io.PrintStream;
-import java.net.*;
-import java.rmi.*;
-import java.util.*;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.util.Map;
 
 /**
  * This program contacts the remote movie database and makes note of a
@@ -17,31 +18,24 @@ public class NoteCharacter {
   public static void main(String[] args) {
     String host = args[0];
     int port = Integer.parseInt(args[1]);
-    long id = Long.parseLong(args[2]);
+    long movieId = Long.parseLong(args[2]);
     String character = args[3];
     long actorId = Long.parseLong(args[4]);
 
-    // Install an RMISecurityManager, if there is not a
-    // SecurityManager already installed
-    if (System.getSecurityManager() == null) {
-      System.setSecurityManager(new RMISecurityManager());
-    }
-
-    String name = "rmi://" + host + ":" + port + "/MovieDatabase";
-
     try {
-      MovieDatabase db = 
-        (MovieDatabase) Naming.lookup(name);
-      db.noteCharacter(id, character, actorId);
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup(MovieDatabase.RMI_OBJECT_NAME);
+      db.noteCharacter(movieId, character, actorId);
 
-      Movie movie = db.getMovie(id);
+      Movie movie = db.getMovie(movieId);
       out.println(movie.getTitle());
       for (Map.Entry entry : movie.getCharacters().entrySet()) {
         out.println("  " + entry.getKey() + "\t" + entry.getValue());
       }
+      System.exit(0);
 
-    } catch (RemoteException | NotBoundException | MalformedURLException ex) {
+    } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
+      System.exit(1);
     }
 
   }

--- a/examples/src/main/java/edu/pdx/cs410J/rmi/ShutdownMovieDatabase.java
+++ b/examples/src/main/java/edu/pdx/cs410J/rmi/ShutdownMovieDatabase.java
@@ -1,7 +1,8 @@
 package edu.pdx.cs410J.rmi;
 
-import java.net.*;
-import java.rmi.*;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
 
 /**
  * This program shutdowns the remote movie database.
@@ -12,27 +13,14 @@ public class ShutdownMovieDatabase {
     String host = args[0];
     int port = Integer.parseInt(args[1]);
 
-    // Install an RMISecurityManager, if there is not a
-    // SecurityManager already installed
-    if (System.getSecurityManager() == null) {
-      System.setSecurityManager(new RMISecurityManager());
-    }
-
-    String name = "rmi://" + host + ":" + port + "/MovieDatabase";
-
     try {
-      MovieDatabase db = 
-        (MovieDatabase) Naming.lookup(name);
+      MovieDatabase db = (MovieDatabase) LocateRegistry.getRegistry(host, port).lookup(MovieDatabase.RMI_OBJECT_NAME);
       db.shutdown();
+      System.exit(0);
 
-    } catch (RemoteException ex) {
+    } catch (RemoteException | NotBoundException ex) {
       ex.printStackTrace(System.err);
-
-    } catch (NotBoundException ex) {
-      ex.printStackTrace(System.err);
-
-    } catch (MalformedURLException ex) {
-      ex.printStackTrace(System.err);
+      System.exit(1);
     }
 
   }

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MoveDatabaseRmiTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MoveDatabaseRmiTest.java
@@ -1,0 +1,56 @@
+package edu.pdx.cs410J.rmi;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.rmi.AlreadyBoundException;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MoveDatabaseRmiTest {
+
+  static final int RMI_PORT = 7777;
+  static final String RMI_HOST = "localhost";
+
+  private MovieDatabase database;
+
+  @BeforeClass
+  public static void bindMovieDatabaseIntoRmiRegistry() throws RemoteException, AlreadyBoundException, MalformedURLException {
+    String name = "/MovieDatabase";
+    MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(new MovieDatabaseImpl(), RMI_PORT);
+    Registry rmiRegistry = LocateRegistry.createRegistry(RMI_PORT);
+    rmiRegistry.bind(name, database);
+  }
+
+  @Before
+  public void lookupMovieDatabase() throws RemoteException, NotBoundException, MalformedURLException {
+    Registry registry = LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
+    this.database = (MovieDatabase) registry.lookup("/MovieDatabase");
+  }
+
+  @AfterClass
+  public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, MalformedURLException, AlreadyBoundException, NotBoundException {
+    Registry registry = LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
+    registry.unbind("/MovieDatabase");
+  }
+
+  @Test
+  public void createMovieInRemoteDatabase() throws RemoteException {
+    String title = "Avengers: Infinity War";
+    int year = 2018;
+    long movieId = this.database.createMovie(title, year);
+    Movie movie = this.database.getMovie(movieId);
+    assertThat(movie.getId(), equalTo(movieId));
+    assertThat(movie.getTitle(), equalTo(title));
+    assertThat(movie.getYear(), equalTo(year));
+  }
+}

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
@@ -1,0 +1,4 @@
+package edu.pdx.cs410J.rmi;
+
+public class MovieDatabaseRmiMainTest {
+}

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
@@ -1,4 +1,37 @@
 package edu.pdx.cs410J.rmi;
 
-public class MovieDatabaseRmiMainTest {
+import com.google.common.collect.Iterables;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MovieDatabaseRmiMainTest extends MovieDatabaseRmiTestCase {
+
+  @Test
+  public void test1CreateMovie() throws RemoteException, NotBoundException {
+    String title = "Black Panther";
+    int year = 2018;
+
+    MainMethodResult result = invokeMain(CreateMovie.class, RMI_HOST, String.valueOf(RMI_PORT), title, String.valueOf(year));
+    assertThat(result.getExitCode(), equalTo(0));
+    assertThat(result.getOut(), containsString("Created movie"));
+    assertThat(result.getErr(), equalTo(""));
+
+    MovieDatabase database = getMovieDatabase();
+    Collection<Movie> movies = database.getMovies();
+    assertThat(movies.size(), equalTo(1));
+    Movie movie = Iterables.getOnlyElement(movies);
+    assertThat(movie.getTitle(), equalTo(title));
+    assertThat(movie.getYear(), equalTo(year));
+  }
+
 }

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTest.java
@@ -1,54 +1,22 @@
 package edu.pdx.cs410J.rmi;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.net.MalformedURLException;
-import java.rmi.AlreadyBoundException;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
-import java.rmi.registry.LocateRegistry;
-import java.rmi.registry.Registry;
-import java.rmi.server.UnicastRemoteObject;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class MovieDatabaseRmiTest {
-
-  static final int RMI_PORT = 7777;
-  static final String RMI_HOST = "localhost";
-
-  private MovieDatabase database;
-
-  @BeforeClass
-  public static void bindMovieDatabaseIntoRmiRegistry() throws RemoteException, AlreadyBoundException, MalformedURLException {
-    String name = "/MovieDatabase";
-    MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(new MovieDatabaseImpl(), RMI_PORT);
-    Registry rmiRegistry = LocateRegistry.createRegistry(RMI_PORT);
-    rmiRegistry.bind(name, database);
-  }
-
-  @Before
-  public void lookupMovieDatabase() throws RemoteException, NotBoundException, MalformedURLException {
-    Registry registry = LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
-    this.database = (MovieDatabase) registry.lookup("/MovieDatabase");
-  }
-
-  @AfterClass
-  public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, MalformedURLException, AlreadyBoundException, NotBoundException {
-    Registry registry = LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
-    registry.unbind("/MovieDatabase");
-  }
+public class MovieDatabaseRmiTest extends MovieDatabaseRmiTestCase {
 
   @Test
-  public void createMovieInRemoteDatabase() throws RemoteException {
+  public void createMovieInRemoteDatabase() throws RemoteException, NotBoundException {
     String title = "Avengers: Infinity War";
     int year = 2018;
-    long movieId = this.database.createMovie(title, year);
-    Movie movie = this.database.getMovie(movieId);
+    MovieDatabase database = getMovieDatabase();
+    long movieId = database.createMovie(title, year);
+    Movie movie = database.getMovie(movieId);
     assertThat(movie.getId(), equalTo(movieId));
     assertThat(movie.getTitle(), equalTo(title));
     assertThat(movie.getYear(), equalTo(year));

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTest.java
@@ -16,7 +16,7 @@ import java.rmi.server.UnicastRemoteObject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class MoveDatabaseRmiTest {
+public class MovieDatabaseRmiTest {
 
   static final int RMI_PORT = 7777;
   static final String RMI_HOST = "localhost";

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
@@ -1,0 +1,46 @@
+package edu.pdx.cs410J.rmi;
+
+import edu.pdx.cs410J.InvokeMainTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.net.MalformedURLException;
+import java.rmi.AlreadyBoundException;
+import java.rmi.NotBoundException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.rmi.server.UnicastRemoteObject;
+
+public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
+  static final int RMI_PORT = 7777;
+  static final String RMI_HOST = "localhost";
+  private static final String RMI_OBJECT_NAME = "/MovieDatabase";
+  private static MovieDatabaseImpl movieDatabaseImpl;
+  private static Registry rmiRegistry;
+
+  @BeforeClass
+  public static void bindMovieDatabaseIntoRmiRegistry() throws RemoteException, AlreadyBoundException, MalformedURLException {
+    movieDatabaseImpl = new MovieDatabaseImpl();
+    MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(movieDatabaseImpl, RMI_PORT);
+    rmiRegistry = LocateRegistry.createRegistry(RMI_PORT);
+    rmiRegistry.bind(RMI_OBJECT_NAME, database);
+  }
+
+  @AfterClass
+  public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, MalformedURLException, AlreadyBoundException, NotBoundException {
+    Registry registry = rmiRegistry;
+    UnicastRemoteObject.unexportObject(movieDatabaseImpl, true);
+    registry.unbind(RMI_OBJECT_NAME);
+    UnicastRemoteObject.unexportObject(rmiRegistry, true);
+    movieDatabaseImpl = null;
+  }
+
+  private static Registry getRmiRegistry() throws RemoteException {
+    return LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
+  }
+
+  static MovieDatabase getMovieDatabase() throws RemoteException, NotBoundException {
+    return (MovieDatabase) getRmiRegistry().lookup(RMI_OBJECT_NAME);
+  }
+}

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
@@ -15,7 +15,6 @@ import java.rmi.server.UnicastRemoteObject;
 public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
   static final int RMI_PORT = 7777;
   static final String RMI_HOST = "localhost";
-  private static final String RMI_OBJECT_NAME = "/MovieDatabase";
   private static MovieDatabaseImpl movieDatabaseImpl;
   private static Registry rmiRegistry;
 
@@ -24,14 +23,14 @@ public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
     movieDatabaseImpl = new MovieDatabaseImpl();
     MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(movieDatabaseImpl, RMI_PORT);
     rmiRegistry = LocateRegistry.createRegistry(RMI_PORT);
-    rmiRegistry.bind(RMI_OBJECT_NAME, database);
+    rmiRegistry.bind(MovieDatabase.RMI_OBJECT_NAME, database);
   }
 
   @AfterClass
   public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, MalformedURLException, AlreadyBoundException, NotBoundException {
     Registry registry = rmiRegistry;
     UnicastRemoteObject.unexportObject(movieDatabaseImpl, true);
-    registry.unbind(RMI_OBJECT_NAME);
+    registry.unbind(MovieDatabase.RMI_OBJECT_NAME);
     UnicastRemoteObject.unexportObject(rmiRegistry, true);
     movieDatabaseImpl = null;
   }
@@ -41,6 +40,6 @@ public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
   }
 
   static MovieDatabase getMovieDatabase() throws RemoteException, NotBoundException {
-    return (MovieDatabase) getRmiRegistry().lookup(RMI_OBJECT_NAME);
+    return (MovieDatabase) getRmiRegistry().lookup(MovieDatabase.RMI_OBJECT_NAME);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19</version>
+        <!--<configuration>-->
+          <!--<argLine>-->
+            <!--&#45;&#45;add-modules java.xml.bind-->
+            <!--&#45;&#45;illegal-access=deny-->
+          <!--</argLine>-->
+        <!--</configuration>-->
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -234,7 +240,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.7.0</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -64,7 +64,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.7.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/web/src/main/java/edu/pdx/cs410J/servlets/MovieDatabaseServlet.java
+++ b/web/src/main/java/edu/pdx/cs410J/servlets/MovieDatabaseServlet.java
@@ -31,12 +31,7 @@ public class MovieDatabaseServlet extends HttpServlet {
 
   @Override
   public void init() throws ServletException {
-    try {
-      this.database = new MovieDatabaseImpl();
-
-    } catch (RemoteException ex) {
-      throw new ServletException(ex);
-    }
+    this.database = new MovieDatabaseImpl();
   }
 
   /**


### PR DESCRIPTION
The use of stub classes generated by the the RMI compiler was deprecated a while ago and is no longer supported in the latest JDKs.  So, update the RMI examples to use the supported methods for registering remote objects.  Along the way, I added some automated tests for the `MovieDatabase` RMI examples.