### PR TITLE
Get tests running again under Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,15 @@
 
             https://github.com/jacoco/jacoco/issues/592
           -->
+          <failIfNoTests>true</failIfNoTests>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.0.0-M3</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -274,6 +282,7 @@
             <additionalClasspathElements>
               <additionalClasspathElement>${project.build.directory}/test-classes</additionalClasspathElement>
             </additionalClasspathElements>
+            <failIfNoTests>true</failIfNoTests>
           </configuration>
           <executions>
             <execution>
@@ -288,6 +297,13 @@
               </configuration>
             </execution>
           </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit47</artifactId>
+              <version>3.0.0-M3</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTest.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTest.java
@@ -1,0 +1,30 @@
+package edu.pdx.cs410J;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class InvokeMainTest extends InvokeMainTestCase {
+
+  @Test
+  public void commandLineArgsWrittenToStandardOutAreCaptured() {
+    String[] args = { "One", "Two", "Three"};
+    MainMethodResult result = invokeMain(InvokeMainTest.class, args);
+    assertThat(result.getExitCode(), equalTo(0));
+
+    String out = result.getTextWrittenToStandardOut();
+    for(String arg : args) {
+      assertThat(out, containsString(arg));
+    }
+  }
+
+  public static void main(String... args) {
+    for (String arg : args) {
+      System.out.println(arg);
+    }
+
+    System.exit(0);
+  }
+}


### PR DESCRIPTION
Somewhere along the line (probably due to Maven plugin updates), the surefire and failsafe plugins stopped running tests on some projects.  I was able to fix this (issues #257) by explicitly configuring those plugins to use the JUnit 4.7+ runners.  For good measure, I also configured the plugins to fail if there are no tests to run.  This might prevent something similar from happening in the future.