### PR TITLE
HttpRequestHelper uses a Map to represent HTTP parameters

### DIFF
--- a/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
+++ b/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
@@ -98,13 +98,6 @@ public class HttpRequestHelper {
     return query;
   }
 
-  private void checkParameters(String... parameters) {
-    if (parameters.length % 2 != 0) {
-      String s = "You must specify an even number of parameters (key/value pairs)";
-      throw new IllegalArgumentException(s);
-    }
-  }
-
   /**
    * Performs an HTTP PUT on the given URL
    *
@@ -113,7 +106,13 @@ public class HttpRequestHelper {
    * @return A <code>Response</code> summarizing the result of the PUT
    */
   protected Response put(String urlString, Map<String, String> parameters) throws IOException {
-    StringBuilder data = encodeParameters(parameters);
+    StringBuilder data = new StringBuilder();
+        parameters.forEach((key, value) -> {
+          data.append(key);
+          data.append("=");
+          data.append(value);
+          data.append("\n");
+        });
 
     URL url = new URL(urlString);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
+++ b/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
@@ -110,20 +110,10 @@ public class HttpRequestHelper {
    *
    * @param urlString The URL to put to
    * @param parameters key/value parameters to the put
-   * @return A <code>Reponse</code> summarizing the result of the PUT
+   * @return A <code>Response</code> summarizing the result of the PUT
    */
-  protected Response put(String urlString, String... parameters) throws IOException {
-    checkParameters(parameters);
-
-    StringBuilder data = new StringBuilder();
-    for (int i = 0; i < parameters.length; i += 2) {
-      String key = parameters[i];
-      String value = parameters[i + 1];
-      data.append(key);
-      data.append("=");
-      data.append(value);
-      data.append("\n");
-    }
+  protected Response put(String urlString, Map<String, String> parameters) throws IOException {
+    StringBuilder data = encodeParameters(parameters);
 
     URL url = new URL(urlString);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -223,7 +213,7 @@ public class HttpRequestHelper {
 
     Response response;
     if (method.equalsIgnoreCase("PUT")) {
-      response = helper.put(url, parameters);
+      response = helper.put(url, map);
 
     } else if (method.equalsIgnoreCase("GET")) {
       response = helper.get(url, map);

--- a/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
+++ b/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -81,15 +80,6 @@ public class HttpRequestHelper {
    */
   protected Response delete(String urlString, Map<String, String> parameters) throws IOException {
     return sendEncodedRequest(urlString, "DELETE", parameters);
-  }
-
-  /**
-   * Performs an HTTP DELETE to the given URL
-   * @param urlString The URL to post to
-   * @return A <code>Response</code> summarizing the result of the POST
-   */
-  protected Response delete(String urlString) throws IOException {
-    return sendEncodedRequest(urlString, "DELETE", Collections.emptyMap());
   }
 
   private Response sendEncodedRequest(String urlString, String requestMethod, Map<String, String> parameters) throws IOException {

--- a/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
+++ b/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
@@ -5,6 +5,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -27,7 +29,7 @@ public class HttpRequestHelper {
     return get(urlString, arrayToMap(parameters));
   }
 
-  private Map<String, String> arrayToMap(String[] parameters) {
+  public static Map<String, String> arrayToMap(String[] parameters) {
     Map<String, String> params = new HashMap<>();
     for (int i = 0; i < parameters.length; i++) {
       String key = parameters[i];
@@ -67,9 +69,8 @@ public class HttpRequestHelper {
    * @param parameters The key/value parameters
    * @return A <code>Response</code> summarizing the result of the POST
    */
-  protected Response post(String urlString, String... parameters) throws IOException {
-    return sendEncodedRequest(urlString, "POST", arrayToMap(parameters));
-
+  protected Response post(String urlString, Map<String, String> parameters) throws IOException {
+    return sendEncodedRequest(urlString, "POST", parameters);
   }
 
   /**
@@ -78,9 +79,17 @@ public class HttpRequestHelper {
    * @param parameters The key/value parameters
    * @return A <code>Response</code> summarizing the result of the POST
    */
-  protected Response delete(String urlString, String... parameters) throws IOException {
-    return sendEncodedRequest(urlString, "DELETE", arrayToMap(parameters));
+  protected Response delete(String urlString, Map<String, String> parameters) throws IOException {
+    return sendEncodedRequest(urlString, "DELETE", parameters);
+  }
 
+  /**
+   * Performs an HTTP DELETE to the given URL
+   * @param urlString The URL to post to
+   * @return A <code>Response</code> summarizing the result of the POST
+   */
+  protected Response delete(String urlString) throws IOException {
+    return sendEncodedRequest(urlString, "DELETE", Collections.emptyMap());
   }
 
   private Response sendEncodedRequest(String urlString, String requestMethod, Map<String, String> parameters) throws IOException {
@@ -113,9 +122,9 @@ public class HttpRequestHelper {
       Map.Entry<String, String> pair = iter.next();
       String key = pair.getKey();
       String value = pair.getValue();
-      query.append(URLEncoder.encode(key, "UTF-8"));
+      query.append(URLEncoder.encode(key, StandardCharsets.UTF_8));
       query.append("=");
-      query.append(URLEncoder.encode(value, "UTF-8"));
+      query.append(URLEncoder.encode(value, StandardCharsets.UTF_8));
       if (iter.hasNext()) {
         query.append("&");
       }
@@ -230,6 +239,7 @@ public class HttpRequestHelper {
     String url = args[1];
     String[] parameters = new String[args.length - 2];
     System.arraycopy(args, 2, parameters, 0, parameters.length);
+    Map<String, String> map = HttpRequestHelper.arrayToMap(parameters);
 
     HttpRequestHelper helper = new HttpRequestHelper();
 
@@ -241,7 +251,7 @@ public class HttpRequestHelper {
       response = helper.get(url, parameters);
 
     } else if (method.equalsIgnoreCase("POST")) {
-      response = helper.post(url, parameters);
+      response = helper.post(url, map);
 
     } else {
       System.err.println("** Unknown method: " + method);

--- a/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
+++ b/examples/src/main/java/edu/pdx/cs410J/web/HttpRequestHelper.java
@@ -18,30 +18,6 @@ public class HttpRequestHelper {
   /**
    * Performs an HTTP GET on the given URL
    *
-   * @param urlString The URL to get
-   * @param parameters The key/value query parameters
-   * @return A <code>Response</code> summarizing the result of the GET
-   */
-  protected Response get(String urlString, String... parameters) throws IOException {
-    checkParameters(parameters);
-
-    return get(urlString, arrayToMap(parameters));
-  }
-
-  public static Map<String, String> arrayToMap(String[] parameters) {
-    Map<String, String> params = new HashMap<>();
-    for (int i = 0; i < parameters.length; i++) {
-      String key = parameters[i];
-      i++;
-      String value = parameters[i];
-      params.put(key, value);
-    }
-    return params;
-  }
-
-  /**
-   * Performs an HTTP GET on the given URL
-   *
    * @param urlString  The URL to get
    * @param parameters The key/value query parameters
    * @return A <code>Response</code> summarizing the result of the GET
@@ -221,6 +197,18 @@ public class HttpRequestHelper {
     }
   }
 
+
+  private static Map<String, String> arrayToMap(String[] parameters) {
+    Map<String, String> params = new HashMap<>();
+    for (int i = 0; i < parameters.length; i++) {
+      String key = parameters[i];
+      i++;
+      String value = parameters[i];
+      params.put(key, value);
+    }
+    return params;
+  }
+
   /**
    * A main method that requests a resource from a URL using a given HTTP method
    */
@@ -238,7 +226,7 @@ public class HttpRequestHelper {
       response = helper.put(url, parameters);
 
     } else if (method.equalsIgnoreCase("GET")) {
-      response = helper.get(url, parameters);
+      response = helper.get(url, map);
 
     } else if (method.equalsIgnoreCase("POST")) {
       response = helper.post(url, map);

--- a/examples/src/test/java/edu/pdx/cs410J/web/HttpRequestHelperTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/web/HttpRequestHelperTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -17,14 +18,14 @@ public class HttpRequestHelperTest {
 
   @Test
   public void testGet() throws IOException {
-    HttpRequestHelper.Response response = helper.get("http://www.google.com");
+    HttpRequestHelper.Response response = helper.get("http://www.google.com", Map.of());
     assertEquals(HttpURLConnection.HTTP_OK, response.getCode());
     assertTrue(response.getContent().contains("Google"));
   }
 
   @Test
   public void testGetWithParameters() throws IOException {
-    HttpRequestHelper.Response response = helper.get("https://www.google.com/search", "p", "Java");
+    HttpRequestHelper.Response response = helper.get("https://www.google.com/search", Map.of("p", "Java"));
     assertEquals(HttpURLConnection.HTTP_OK, response.getCode());
     assertTrue(response.getContent().contains("Java"));
 

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -10,11 +15,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link AirlineRestClient}

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
@@ -56,7 +56,7 @@ public class AirlineRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -15,6 +10,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link AirlineRestClient}

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -13,6 +8,11 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -8,6 +8,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -8,11 +13,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -5,11 +10,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * A helper class for accessing the rest client.  Note that this class provides

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -10,6 +5,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * A helper class for accessing the rest client.  Note that this class provides

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
@@ -38,7 +38,7 @@ public class AirlineRestClient extends HttpRequestHelper
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException {
-    Response response = get(this.url);
+    Response response = get(this.url, Map.of());
     return Messages.parseDictionary(response.getContent());
   }
 
@@ -46,24 +46,24 @@ public class AirlineRestClient extends HttpRequestHelper
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException {
-    Response response = get(this.url, "word", word);
+    Response response = get(this.url, Map.of("word", word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
     return Messages.parseDictionaryEntry(content).getValue();
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL("word", word, "definition", definition);
+    Response response = postToMyURL(Map.of("word", word, "definition", definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   @VisibleForTesting
-  Response postToMyURL(String... dictionaryEntries) throws IOException {
+  Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
     return post(this.url, dictionaryEntries);
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    Response response = delete(this.url);
+    Response response = delete(this.url, Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -15,6 +10,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link AppointmentBookRestClient}

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -10,11 +15,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link AppointmentBookRestClient}

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -56,7 +56,7 @@ public class AppointmentBookRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -13,6 +8,11 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -8,6 +8,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -8,11 +13,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -10,6 +5,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * A helper class for accessing the rest client

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -5,11 +10,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * A helper class for accessing the rest client

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
@@ -35,7 +35,7 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException {
-    Response response = get(this.url);
+    Response response = get(this.url, Map.of());
     return Messages.parseDictionary(response.getContent());
   }
 
@@ -43,24 +43,24 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException {
-    Response response = get(this.url, "word", word);
+    Response response = get(this.url, Map.of("word", word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
     return Messages.parseDictionaryEntry(content).getValue();
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL("word", word, "definition", definition);
+    Response response = postToMyURL(Map.of("word", word, "definition", definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   @VisibleForTesting
-  Response postToMyURL(String... dictionaryEntries) throws IOException {
+  Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
     return post(this.url, dictionaryEntries);
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    Response response = delete(this.url);
+    Response response = delete(this.url, Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -13,6 +8,11 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -8,6 +8,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +44,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
@@ -8,11 +13,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 public class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
@@ -56,7 +56,7 @@ public class PhoneBillRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -10,11 +15,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link PhoneBillRestClient}

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -15,6 +10,11 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * Integration test that tests the REST calls made by {@link PhoneBillRestClient}

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
@@ -1,3 +1,8 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -5,11 +10,6 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-
-#set($symbol_pound='#')
-  #set($symbol_dollar='$')
-  #set($symbol_escape='\' )
-  package ${package};
 
 /**
  * A helper class for accessing the rest client.  Note that this class provides

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
@@ -1,8 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
-package ${package};
-
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs410J.web.HttpRequestHelper;
 
@@ -10,6 +5,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+
+#set($symbol_pound='#')
+  #set($symbol_dollar='$')
+  #set($symbol_escape='\' )
+  package ${package};
 
 /**
  * A helper class for accessing the rest client.  Note that this class provides

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
@@ -38,7 +38,7 @@ public class PhoneBillRestClient extends HttpRequestHelper
      * Returns all dictionary entries from the server
      */
     public Map<String, String> getAllDictionaryEntries() throws IOException {
-      Response response = get(this.url);
+      Response response = get(this.url, Map.of());
       return Messages.parseDictionary(response.getContent());
     }
 
@@ -46,24 +46,24 @@ public class PhoneBillRestClient extends HttpRequestHelper
      * Returns the definition for the given word
      */
     public String getDefinition(String word) throws IOException {
-      Response response = get(this.url, "word", word);
+      Response response = get(this.url, Map.of("word", word));
       throwExceptionIfNotOkayHttpStatus(response);
       String content = response.getContent();
       return Messages.parseDictionaryEntry(content).getValue();
     }
 
     public void addDictionaryEntry(String word, String definition) throws IOException {
-      Response response = postToMyURL("word", word, "definition", definition);
+      Response response = postToMyURL(Map.of("word", word, "definition", definition));
       throwExceptionIfNotOkayHttpStatus(response);
     }
 
     @VisibleForTesting
-    Response postToMyURL(String... dictionaryEntries) throws IOException {
+    Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
       return post(this.url, dictionaryEntries);
     }
 
     public void removeAllDictionaryEntries() throws IOException {
-      Response response = delete(this.url);
+      Response response = delete(this.url, Map.of());
       throwExceptionIfNotOkayHttpStatus(response);
     }
 

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
@@ -53,7 +53,7 @@ public class AirlineRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/IndexDotHtmlIT.java
@@ -5,6 +5,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,7 +41,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
@@ -60,7 +60,7 @@ public class AirlineRestClient extends HttpRequestHelper
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    Response response = delete(this.url);
+    Response response = delete(this.url, Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
@@ -35,7 +35,7 @@ public class AirlineRestClient extends HttpRequestHelper
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException {
-    Response response = get(this.url);
+    Response response = get(this.url, Map.of());
     return Messages.parseDictionary(response.getContent());
   }
 
@@ -43,7 +43,7 @@ public class AirlineRestClient extends HttpRequestHelper
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException {
-    Response response = get(this.url, "word", word);
+    Response response = get(this.url, Map.of("word", word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
     return Messages.parseDictionaryEntry(content).getValue();

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
@@ -50,12 +50,12 @@ public class AirlineRestClient extends HttpRequestHelper
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL("word", word, "definition", definition);
+    Response response = postToMyURL(Map.of("word", word, "definition", definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   @VisibleForTesting
-  Response postToMyURL(String... dictionaryEntries) throws IOException {
+  Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
     return post(this.url, dictionaryEntries);
   }
 

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
@@ -53,7 +53,7 @@ public class AppointmentBookRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/IndexDotHtmlIT.java
@@ -5,6 +5,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,7 +41,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
@@ -57,7 +57,7 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    Response response = delete(this.url);
+    Response response = delete(this.url, Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
@@ -32,7 +32,7 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException {
-    Response response = get(this.url);
+    Response response = get(this.url, Map.of());
     return Messages.parseDictionary(response.getContent());
   }
 
@@ -40,7 +40,7 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException {
-    Response response = get(this.url, "word", word);
+    Response response = get(this.url, Map.of("word", word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
     return Messages.parseDictionaryEntry(content).getValue();

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
@@ -47,12 +47,12 @@ public class AppointmentBookRestClient extends HttpRequestHelper {
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL("word", word, "definition", definition);
+    Response response = postToMyURL(Map.of("word", word, "definition", definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   @VisibleForTesting
-  Response postToMyURL(String... dictionaryEntries) throws IOException {
+  Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
     return post(this.url, dictionaryEntries);
   }
 

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/IndexDotHtmlIT.java
@@ -5,6 +5,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper.Response;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,7 +41,7 @@ public class IndexDotHtmlIT {
     }
 
     public Response getIndexDotHtml() throws IOException {
-      return get(this.url);
+      return get(this.url, Map.of());
     }
   }
 }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
@@ -53,7 +53,7 @@ public class PhoneBillRestClientIT {
   @Test
   public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
-    HttpRequestHelper.Response response = client.postToMyURL();
+    HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));
     assertThat(response.getCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
   }

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
@@ -35,7 +35,7 @@ public class PhoneBillRestClient extends HttpRequestHelper
      * Returns all dictionary entries from the server
      */
     public Map<String, String> getAllDictionaryEntries() throws IOException {
-      Response response = get(this.url);
+      Response response = get(this.url, Map.of());
       return Messages.parseDictionary(response.getContent());
     }
 
@@ -43,7 +43,7 @@ public class PhoneBillRestClient extends HttpRequestHelper
      * Returns the definition for the given word
      */
     public String getDefinition(String word) throws IOException {
-      Response response = get(this.url, "word", word);
+      Response response = get(this.url, Map.of("word", word));
       throwExceptionIfNotOkayHttpStatus(response);
       String content = response.getContent();
       return Messages.parseDictionaryEntry(content).getValue();

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
@@ -50,12 +50,12 @@ public class PhoneBillRestClient extends HttpRequestHelper
     }
 
     public void addDictionaryEntry(String word, String definition) throws IOException {
-      Response response = postToMyURL("word", word, "definition", definition);
+      Response response = postToMyURL(Map.of("word", word, "definition", definition));
       throwExceptionIfNotOkayHttpStatus(response);
     }
 
     @VisibleForTesting
-    Response postToMyURL(String... dictionaryEntries) throws IOException {
+    Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
       return post(this.url, dictionaryEntries);
     }
 

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
@@ -60,7 +60,7 @@ public class PhoneBillRestClient extends HttpRequestHelper
     }
 
     public void removeAllDictionaryEntries() throws IOException {
-      Response response = delete(this.url);
+      Response response = delete(this.url, Map.of());
       throwExceptionIfNotOkayHttpStatus(response);
     }
 

--- a/web/src/it/java/edu/pdx/cs410J/servlets/FamilyTreeServletIT.java
+++ b/web/src/it/java/edu/pdx/cs410J/servlets/FamilyTreeServletIT.java
@@ -60,7 +60,7 @@ public class FamilyTreeServletIT extends HttpRequestHelper {
    * Returns the person with the given id
    */
   private Person getPerson(int id) throws IOException {
-    Response response = get(PERSON_URL + "/" + id);
+    Response response = get(PERSON_URL + "/" + id, Map.of());
 
     if (response.getCode() == HTTP_NOT_FOUND) {
       return null;

--- a/web/src/it/java/edu/pdx/cs410J/servlets/FamilyTreeServletIT.java
+++ b/web/src/it/java/edu/pdx/cs410J/servlets/FamilyTreeServletIT.java
@@ -8,10 +8,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -36,24 +33,18 @@ public class FamilyTreeServletIT extends HttpRequestHelper {
       throw new IllegalArgumentException(s);
     }
 
-    List<String> params = new ArrayList<String>();
+    Map<String, String> params = new HashMap<>();
 
-    params.add("Gender");
-    params.add(person.getGender() == Person.MALE ? "Male" : "Female");
+    params.put("Gender", person.getGender() == Person.MALE ? "Male" : "Female");
 
-    params.add("FirstName");
-    params.add(person.getFirstName());
-    params.add("MiddleName");
-    params.add(person.getMiddleName());
-    params.add("LastName");
-    params.add(person.getLastName());
+    params.put("FirstName", person.getFirstName());
+    params.put("MiddleName", person.getMiddleName());
+    params.put("LastName", person.getLastName());
 
-    params.add("DateOfBirth");
-    params.add(String.valueOf(person.getDateOfBirth().getTime()));
-    params.add("DateOfDeath");
-    params.add(String.valueOf(person.getDateOfBirth().getTime()));
+    params.put("DateOfBirth", String.valueOf(person.getDateOfBirth().getTime()));
+    params.put("DateOfDeath", String.valueOf(person.getDateOfBirth().getTime()));
 
-    Response response = post(PERSON_URL, params.toArray(new String[params.size()]));
+    Response response = post(PERSON_URL, params);
     if (response.getCode() != HTTP_OK) {
       String s = "Could not create Person (error code " + response.getCode() + "): " + response.getContent();
       throw new IllegalArgumentException(s);

--- a/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
+++ b/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
@@ -57,7 +57,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     createMovie(title1, "2007");
     String title2 = "testGetAllMovies2";
     createMovie(title2, "2013");
-    Response response = get(getResourceURL(MOVIES));
+    Response response = get(getResourceURL(MOVIES), Map.of());
     assertNotNull(response);
     String content = response.getContent();
     assertTrue(content, content.contains(title1));
@@ -72,7 +72,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     String title = "testGetOneMovie" + "-title";
     String year = "1997";
     long id = createMovie(title, year);
-    Response response = get(getResourceURL(MOVIES), "id", String.valueOf(id));
+    Response response = get(getResourceURL(MOVIES), Map.of("id", String.valueOf(id)));
     assertNotNull(response);
     assertTrue(response.getContent(), response.getContent().contains(title));
     assertTrue(response.getContent(), response.getContent().contains(year));
@@ -93,7 +93,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     createMovie(title2, year2);
     createMovie(title3, year3);
 
-    Response response = get(getResourceURL(MOVIES), "title", query);
+    Response response = get(getResourceURL(MOVIES), Map.of("title", query));
     assertTrue(response.getContent(), response.getContent().contains(title1));
     assertFalse(response.getContent(), response.getContent().contains(title2));
     assertTrue(response.getContent(), response.getContent().contains(title3));
@@ -113,7 +113,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     createMovie(title2, year2);
     createMovie(title3, year3);
 
-    Response response = get(getResourceURL(MOVIES), "year", query);
+    Response response = get(getResourceURL(MOVIES), Map.of("year", query));
     assertFalse(response.getContent(), response.getContent().contains(title1));
     assertTrue(response.getContent(), response.getContent().contains(title2));
     assertTrue(response.getContent(), response.getContent().contains(title3));
@@ -135,7 +135,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     createMovie(title2, year2);
     createMovie(title3, year3);
 
-    Response response = get(getResourceURL(MOVIES), "title", titleQuery);
+    Response response = get(getResourceURL(MOVIES), Map.of("title", titleQuery));
     assertTrue(response.getContent(), response.getContent().contains(title1));
     assertFalse(response.getContent(), response.getContent().contains(title2));
     assertTrue(response.getContent(), response.getContent().contains(title3));
@@ -152,7 +152,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     assertEquals(1, response.getContentLines());
     assertEquals(String.valueOf(id), response.getContent());
 
-    response = get(getResourceURL(MOVIES), "id", String.valueOf(id));
+    response = get(getResourceURL(MOVIES), Map.of("id", String.valueOf(id)));
     assertEquals(HTTP_OK, response.getCode());
     assertEquals(1, response.getContentLines());
     assertTrue(response.getContent().contains(newTitle));
@@ -166,7 +166,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
     Response response = delete(getResourceURL(MOVIES), Map.of("id", String.valueOf(id)));
     assertThat(response.getContent(), response.getCode(), equalTo(HTTP_OK));
 
-    response = get(getResourceURL(MOVIES), "id", String.valueOf(id));
+    response = get(getResourceURL(MOVIES), Map.of("id", String.valueOf(id)));
     assertThat(response.getContent(), response.getCode(), equalTo(HTTP_NOT_FOUND));
   }
 

--- a/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
+++ b/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
@@ -147,7 +147,8 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
 
     String newTitle = "New Title";
     String newYear = "2008";
-    Response response = put(getResourceURL(MOVIES), "id", String.valueOf(id), "title", newTitle, "year", newYear);
+    Response response =
+      put(getResourceURL(MOVIES), Map.of("id", String.valueOf(id), "title", newTitle, "year", newYear));
     assertEquals(response.getContent(), HTTP_OK, response.getCode());
     assertEquals(1, response.getContentLines());
     assertEquals(String.valueOf(id), response.getContent());

--- a/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
+++ b/web/src/it/java/edu/pdx/cs410J/servlets/MovieDatabaseServletIT.java
@@ -4,6 +4,7 @@ import edu.pdx.cs410J.web.HttpRequestHelper;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -25,17 +26,17 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
 
   @Test
   public void testMissingTitle() throws IOException {
-    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES)).getCode());
+    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES), Map.of()).getCode());
   }
 
   @Test
   public void testMissingYear() throws IOException {
-    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES), "title", "Title").getCode());
+    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES), Map.of("title", "Title")).getCode());
   }
 
   @Test
   public void testMalformedYear() throws IOException {
-    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES), "title", "Title", "year", "asdfa").getCode());
+    assertEquals(HTTP_BAD_REQUEST, post(getResourceURL(MOVIES), Map.of("title", "Title", "year", "asdfa")).getCode());
   }
 
   @Test
@@ -44,7 +45,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
   }
 
   private long createMovie(String title, String year) throws IOException {
-    Response response = post(getResourceURL(MOVIES), "title", title, "year", year);
+    Response response = post(getResourceURL(MOVIES), Map.of("title", title, "year", year));
     assertEquals(response.getContent(), HTTP_OK, response.getCode());
     assertNotNull(response.getContent());
     return Long.parseLong(response.getContent().trim());
@@ -162,7 +163,7 @@ public class MovieDatabaseServletIT extends HttpRequestHelper {
   public void canDeleteMovieFromServer() throws IOException {
     long id = createMovie("Movie to be deleted", "2015");
 
-    Response response = delete(getResourceURL(MOVIES), "id", String.valueOf(id));
+    Response response = delete(getResourceURL(MOVIES), Map.of("id", String.valueOf(id)));
     assertThat(response.getContent(), response.getCode(), equalTo(HTTP_OK));
 
     response = get(getResourceURL(MOVIES), "id", String.valueOf(id));


### PR DESCRIPTION
To address #245, replace the vararg `String` parameter to methods like `get` and `post` in `HttpRequestHelper` with a `Map<String, String>`.  Now that Java 9 has a `Map.of` method, this works out quite nicely.