### PR TITLE
Handle plain/text POA emails

### DIFF
--- a/grader/src/it/java/edu/pdx/cs410J/grader/GreenmailIntegrationTestCase.java
+++ b/grader/src/it/java/edu/pdx/cs410J/grader/GreenmailIntegrationTestCase.java
@@ -1,7 +1,10 @@
 package edu.pdx.cs410J.grader;
 
 import com.icegreen.greenmail.imap.AuthorizationException;
+import com.icegreen.greenmail.imap.ImapHostManager;
 import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.store.FolderListener;
+import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
@@ -87,5 +90,37 @@ public class GreenmailIntegrationTestCase {
     store.connect(emailServerHost, imapsPort, imapUserName, imapPassword);
 
     return store;
+  }
+
+  protected void moveEmailsFromInboxToFolder(GreenMailUser user, String folderName) throws AuthorizationException, FolderException {
+    ImapHostManager manager = emailServer.getManagers().getImapHostManager();
+    MailFolder submissions = manager.createMailbox(user, folderName);
+    MailFolder inbox = manager.getInbox(user);
+    inbox.addListener(new FolderListener() {
+      @Override
+      public void expunged(int msn) {
+
+      }
+
+      @Override
+      public void added(int msn) {
+        try {
+          inbox.copyMessage(msn, submissions);
+
+        } catch (FolderException ex) {
+          throw new IllegalStateException("Can't copy message to submissions folder", ex);
+        }
+      }
+
+      @Override
+      public void flagsUpdated(int msn, Flags flags, Long uid) {
+
+      }
+
+      @Override
+      public void mailboxDeleted() {
+
+      }
+    });
   }
 }

--- a/grader/src/it/java/edu/pdx/cs410J/grader/SendAndReceiveMultipartWithGreenmailIT.java
+++ b/grader/src/it/java/edu/pdx/cs410J/grader/SendAndReceiveMultipartWithGreenmailIT.java
@@ -1,10 +1,7 @@
 package edu.pdx.cs410J.grader;
 
 import com.icegreen.greenmail.imap.AuthorizationException;
-import com.icegreen.greenmail.imap.ImapHostManager;
 import com.icegreen.greenmail.store.FolderException;
-import com.icegreen.greenmail.store.FolderListener;
-import com.icegreen.greenmail.store.MailFolder;
 import com.icegreen.greenmail.user.GreenMailUser;
 import org.junit.Test;
 
@@ -32,39 +29,7 @@ public class SendAndReceiveMultipartWithGreenmailIT extends GreenmailIntegration
 
   @Override
   protected void doSomethingWithUser(GreenMailUser user) throws FolderException, AuthorizationException {
-    moveEmailsFromInboxToProjectSubmissions(user);
-  }
-
-  private void moveEmailsFromInboxToProjectSubmissions(GreenMailUser user) throws AuthorizationException, FolderException {
-    ImapHostManager manager = emailServer.getManagers().getImapHostManager();
-    MailFolder submissions = manager.createMailbox(user, emailFolderName);
-    MailFolder inbox = manager.getInbox(user);
-    inbox.addListener(new FolderListener() {
-      @Override
-      public void expunged(int msn) {
-
-      }
-
-      @Override
-      public void added(int msn) {
-        try {
-          inbox.copyMessage(msn, submissions);
-
-        } catch (FolderException ex) {
-          throw new IllegalStateException("Can't copy message to submissions folder", ex);
-        }
-      }
-
-      @Override
-      public void flagsUpdated(int msn, Flags flags, Long uid) {
-
-      }
-
-      @Override
-      public void mailboxDeleted() {
-
-      }
-    });
+    moveEmailsFromInboxToFolder(user, emailFolderName);
   }
 
 

--- a/grader/src/it/java/edu/pdx/cs410J/grader/poa/POASubmissionsDownloaderIT.java
+++ b/grader/src/it/java/edu/pdx/cs410J/grader/poa/POASubmissionsDownloaderIT.java
@@ -1,0 +1,100 @@
+package edu.pdx.cs410J.grader.poa;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.icegreen.greenmail.imap.AuthorizationException;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.user.GreenMailUser;
+import edu.pdx.cs410J.grader.GreenmailIntegrationTestCase;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Transport;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class POASubmissionsDownloaderIT extends GreenmailIntegrationTestCase  {
+
+  @Test
+  public void multipartMessageWithTextPart() throws MessagingException {
+    String subject = "Email subject";
+    String poa = "This is my POA";
+    String sender = "sender@email.com";
+    mailMultiPartPOA(sender, subject, poa);
+
+    assertEmailIsProperlyProcessed(subject, poa, sender);
+  }
+
+  @Test
+  public void textPlainMessage() throws MessagingException {
+    String subject = "Email subject";
+    String poa = "This is my POA";
+    String sender = "sender@email.com";
+    mailTextPlainPOA(sender, subject, poa);
+
+    assertEmailIsProperlyProcessed(subject, poa, sender);
+  }
+
+  private void mailTextPlainPOA(String sender, String subject, String poa) throws MessagingException {
+    MimeMessage message = newEmailTo(newEmailSession(true), emailAddress, subject);
+    message.setFrom(sender);
+
+    message.setContent(poa, "text/plain");
+
+    Transport.send(message);
+  }
+
+  private void assertEmailIsProperlyProcessed(String subject, String poa, String sender) {
+    EventBus bus = new EventBusThatPublishesUnhandledExceptionEvents();
+    POASubmissionHandler handler = mock(POASubmissionHandler.class);
+    bus.register(handler);
+
+    POASubmissionsDownloader downloader = new POASubmissionsDownloader(bus);
+    EmailCredentials credentials = new EmailCredentials(this.imapUserName, this.imapPassword);
+    downloader.downloadSubmissions(this.emailServerHost, this.imapsPort, credentials);
+
+    ArgumentCaptor<POASubmission> captor = ArgumentCaptor.forClass(POASubmission.class);
+    verify(handler).handlePOASubmission(captor.capture());
+
+    POASubmission submission = captor.getValue();
+    assertThat(submission.getSubject(), equalTo(subject));
+    assertThat(submission.getContent(), equalTo(poa));
+    assertThat(submission.getSubmitter(), equalTo(sender));
+  }
+
+  private void mailMultiPartPOA(String sender, String emailSubject, String poa) throws MessagingException {
+    MimeMessage message = newEmailTo(newEmailSession(true), emailAddress, emailSubject);
+    message.setFrom(sender);
+
+    MimeBodyPart textPart = new MimeBodyPart();
+    textPart.setContent(poa, "text/plain");
+    textPart.setDisposition("inline");
+
+    Multipart mp = new MimeMultipart();
+    mp.addBodyPart(textPart);
+
+    message.setContent(mp);
+
+    Transport.send(message);
+  }
+
+  @Override
+  protected void doSomethingWithUser(GreenMailUser user) throws FolderException, AuthorizationException {
+    super.doSomethingWithUser(user);
+
+    moveEmailsFromInboxToFolder(user, POASubmissionsDownloader.POA_FOLDER_NAME);
+  }
+
+  private interface POASubmissionHandler {
+    @Subscribe
+    void handlePOASubmission(POASubmission submission);
+  }
+}

--- a/grader/src/main/java/edu/pdx/cs410J/grader/GraderEmailAccount.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/GraderEmailAccount.java
@@ -30,7 +30,7 @@ public class GraderEmailAccount {
   }
 
   @VisibleForTesting
-  GraderEmailAccount(String emailServerHostName, int emailServerPort, String userName, String password, boolean trustLocalhostSSL) {
+  public GraderEmailAccount(String emailServerHostName, int emailServerPort, String userName, String password, boolean trustLocalhostSSL) {
     this.userName = userName;
     this.password = password;
     this.emailServerHostName = emailServerHostName;
@@ -64,9 +64,22 @@ public class GraderEmailAccount {
     printMessageInformation(message);
     if (isMultipartMessage(message)) {
       processAttachments(message, processor);
+
+    } else if (isTextPlainMessage(message)) {
+       processPlainTextBody(message, processor);
+
     } else {
       warnOfUnexpectedMessage(message, "Fetched a message that wasn't multipart: " + message.getContentType());
     }
+  }
+
+  private void processPlainTextBody(Message message, EmailAttachmentProcessor processor) throws IOException, MessagingException {
+    processor.processAttachment(message, "TextPlainBody", message.getInputStream());
+
+  }
+
+  private boolean isTextPlainMessage(Message message) throws MessagingException {
+    return message.isMimeType("text/plain");
   }
 
   private void processAttachments(Message message, EmailAttachmentProcessor processor) throws MessagingException, IOException {

--- a/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsDownloader.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/poa/POASubmissionsDownloader.java
@@ -1,5 +1,6 @@
 package edu.pdx.cs410J.grader.poa;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.io.CharStreams;
@@ -22,6 +23,7 @@ import java.util.Date;
 @Singleton
 public class POASubmissionsDownloader {
 
+  static final String POA_FOLDER_NAME = "poa";
   private final EventBus bus;
 
   @Inject
@@ -33,9 +35,18 @@ public class POASubmissionsDownloader {
   @Subscribe
   public void downloadSubmissions(EmailCredentials credentials) throws MessagingException {
     GraderEmailAccount account = new GraderEmailAccount(credentials.getEmailAddress(), credentials.getPassword());
-    account.fetchAttachmentsFromUnreadMessagesInFolder("poa", new POAAttachmentProcessor());
+    downloadSubmissions(account);
   }
 
+  @VisibleForTesting
+  void downloadSubmissions(String emailServerHostName, int emailServerHostPort, EmailCredentials credentials) {
+    GraderEmailAccount account = new GraderEmailAccount(emailServerHostName, emailServerHostPort, credentials.getEmailAddress(), credentials.getPassword(), true);
+    downloadSubmissions(account);
+  }
+
+  private void downloadSubmissions(GraderEmailAccount account) {
+    account.fetchAttachmentsFromUnreadMessagesInFolder(POA_FOLDER_NAME, new POAAttachmentProcessor());
+  }
   private void extractPOASubmissionFromAttachment(Message message, String fileName, InputStream inputStream) {
     try {
       String submitter = getSender(message);


### PR DESCRIPTION
Address issue #184 by handling POA emails that have a content type of "text/plain" instead of ignoring them.  As it turns out, I had actually implemented this a couple of years ago, but because I was trying to also fix another, unrelated bug in the same change set, I never merged it.  Bad Dave.