### PR TITLE
Correctly warn when test classes aren't submitted

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -524,11 +524,16 @@ public class Submit extends EmailSender {
   }
 
   protected void warnIfTestClassesAreNotSubmitted(Set<File> sourceFiles) {
-    boolean wereTestClassessSubmitted = sourceFiles.stream().anyMatch((f) -> f.getName().contains("test"));
+    boolean wereTestClassessSubmitted = submittedTestClasses(sourceFiles);
     if (!wereTestClassessSubmitted && !this.isSubmittingKoans) {
       out.println("*** WARNING: You are not submitting a \"test\" directory.\n" +
         "    Your unit tests are executed as part of the grading of your project.\n");
     }
+  }
+
+  @VisibleForTesting
+  static boolean submittedTestClasses(Set<File> sourceFiles) {
+    return sourceFiles.stream().anyMatch((f) -> f.getPath().contains("test"));
   }
 
   private boolean doesUserWantToSubmit() {

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -205,6 +206,24 @@ public class SubmitTest {
     assertThat(Submit.canFileBeSubmitted("src/main/resources/edu/pdx/cs410J/student/text.txt"), equalTo(true));
     assertThat(Submit.canFileBeSubmitted("src/test/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
     assertThat(Submit.canFileBeSubmitted("src/it/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
+  }
+
+  @Test
+  public void testClassesWereSubmitted() {
+    Set files = Set.of(
+      makeFileWithPath("src", "test", "java", "edu", "pdx", "cs410J", "student", "StudentTest.java")
+    );
+
+    assertThat(Submit.submittedTestClasses(files), equalTo(true));
+  }
+
+  @Test
+  public void notestClassesWereSubmitted() {
+    Set files = Set.of(
+      makeFileWithPath("src", "main", "java", "edu", "pdx", "cs410J", "student", "Student.java")
+    );
+
+    assertThat(Submit.submittedTestClasses(files), equalTo(false));
   }
 
 }


### PR DESCRIPTION
Fixed a small bug in the `Submit` program that caused #285.