### PR TITLE
Issue 288 readme file in project

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -376,7 +376,7 @@ public class Submit extends EmailSender {
     }
 
     // Does the file name end in .java?
-    if (!canFileBeSubmitted(name)) {
+    if (!canFileBeSubmitted(file)) {
       err.println("** Not submitting file " + file +
         " because does end in \".java\"");
       return false;
@@ -386,18 +386,17 @@ public class Submit extends EmailSender {
   }
 
   @VisibleForTesting
-  static boolean canFileBeSubmitted(String name) {
-    if (name.endsWith(".java")) {
-        return true;
+  static boolean canFileBeSubmitted(File file) {
+    String path = file.getPath();
 
-    } else if (name.endsWith(".html")) {
-      return true;
+    if (path.contains("/java/")) {
+      return path.endsWith(".java");
 
-    } else if (name.endsWith(".xml")) {
-      return true;
+    } else if (path.contains("/javadoc/")) {
+      return path.endsWith(".html");
 
-    } else if (name.endsWith(".txt")) {
-      return true;
+    } else if (path.contains("/resources")) {
+      return path.endsWith(".xml") || path.endsWith(".txt");
 
     } else {
       return false;

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
@@ -146,9 +146,13 @@ public class SubmitTest {
 
   @Test
   public void canSubmitPackageHtmlForMainTestAndIT() {
-    assertThat(Submit.canFileBeSubmitted("src/main/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
-    assertThat(Submit.canFileBeSubmitted("src/test/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
-    assertThat(Submit.canFileBeSubmitted("src/main/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/main/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/test/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/it/javadoc/edu/pdx/cs410J/student/package.html"), equalTo(true));
+  }
+
+  private boolean canFileBeSubmitted(String fileName) {
+    return Submit.canFileBeSubmitted(new File(fileName));
   }
 
   @Test
@@ -160,8 +164,8 @@ public class SubmitTest {
 
   @Test
   public void canSubmitXmlFilesFromTestResourcesDirectory() {
-    assertThat(Submit.canFileBeSubmitted("src/test/resources/edu/pdx/cs410J/student/testData.xml"), equalTo(true));
-    assertThat(Submit.canFileBeSubmitted("src/it/resources/edu/pdx/cs410J/student/testData.xml"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/test/resources/edu/pdx/cs410J/student/testData.xml"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/it/resources/edu/pdx/cs410J/student/testData.xml"), equalTo(true));
   }
 
   @Test
@@ -202,10 +206,17 @@ public class SubmitTest {
   }
 
   @Test
-  public void canSubmitTxtFilesFromesourcesDirectory() {
-    assertThat(Submit.canFileBeSubmitted("src/main/resources/edu/pdx/cs410J/student/text.txt"), equalTo(true));
-    assertThat(Submit.canFileBeSubmitted("src/test/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
-    assertThat(Submit.canFileBeSubmitted("src/it/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
+  public void canSubmitTxtFilesFromResourcesDirectory() {
+    assertThat(canFileBeSubmitted("src/main/resources/edu/pdx/cs410J/student/text.txt"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/test/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
+    assertThat(canFileBeSubmitted("src/it/resources/edu/pdx/cs410J/student/testData.txt"), equalTo(true));
+  }
+
+  @Test
+  public void cannotSubmitTxtFilesFromJavaDirectory() {
+    assertThat(canFileBeSubmitted("src/main/java/edu/pdx/cs410J/student/text.txt"), equalTo(false));
+    assertThat(canFileBeSubmitted("src/test/java/edu/pdx/cs410J/student/testData.txt"), equalTo(false));
+    assertThat(canFileBeSubmitted("src/it/java/edu/pdx/cs410J/student/testData.txt"), equalTo(false));
   }
 
   @Test

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -15,6 +15,12 @@
         <include>**/*.html</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.txt</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/test/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/README.txt
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/README.txt
@@ -1,0 +1,4 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+This is a README file!

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
@@ -1,0 +1,34 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * A unit test for code in the <code>Project1</code> class.  This is different
+ * from {@link Project1IT} which is an integration test (and can handle the calls
+ * to {@link System${symbol_pound}exit(int)} and the like.
+ */
+public class Project1Test {
+
+  @Test
+  public void readmeCanBeReadAsResource() throws IOException {
+    try (
+      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+    ) {
+      assertThat(readme, not(nullValue()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(readme));
+      String line = reader.readLine();
+      assertThat(line, containsString("This is a README file!"));
+    }
+  }
+}

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -15,6 +15,12 @@
         <include>**/*.html</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.txt</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/test/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -72,7 +72,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>${package}.Project1</mainClass>
+              <mainClass>edu.pdx.cs410J.apptbook.Project1</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/README.txt
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/README.txt
@@ -1,0 +1,4 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+This is a README file!

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
@@ -1,0 +1,34 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package};
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * A unit test for code in the <code>Project1</code> class.  This is different
+ * from {@link Project1IT} which is an integration test (and can handle the calls
+ * to {@link System${symbol_pound}exit(int)} and the like.
+ */
+public class Project1Test {
+
+  @Test
+  public void readmeCanBeReadAsResource() throws IOException {
+    try (
+      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+    ) {
+      assertThat(readme, not(nullValue()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(readme));
+      String line = reader.readLine();
+      assertThat(line, containsString("This is a README file!"));
+    }
+  }
+}

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -15,6 +15,12 @@
         <include>**/*.html</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>**/*.txt</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/test/java</directory>
       <includes>

--- a/projects-parent/originals-parent/airline/src/main/resources/edu/pdx/cs410J/airline/README.txt
+++ b/projects-parent/originals-parent/airline/src/main/resources/edu/pdx/cs410J/airline/README.txt
@@ -1,0 +1,1 @@
+This is a README file!

--- a/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/Project1Test.java
+++ b/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/Project1Test.java
@@ -1,0 +1,31 @@
+package edu.pdx.cs410J.airline;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * A unit test for code in the <code>Project1</code> class.  This is different
+ * from {@link Project1IT} which is an integration test (and can handle the calls
+ * to {@link System#exit(int)} and the like.
+ */
+public class Project1Test {
+
+  @Test
+  public void readmeCanBeReadAsResource() throws IOException {
+    try (
+      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+    ) {
+      assertThat(readme, not(nullValue()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(readme));
+      String line = reader.readLine();
+      assertThat(line, containsString("This is a README file!"));
+    }
+  }
+}

--- a/projects-parent/originals-parent/apptbook/src/main/resources/edu/pdx/cs410J/apptbook/README.txt
+++ b/projects-parent/originals-parent/apptbook/src/main/resources/edu/pdx/cs410J/apptbook/README.txt
@@ -1,0 +1,1 @@
+This is a README file!

--- a/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/Project1Test.java
+++ b/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/Project1Test.java
@@ -1,0 +1,31 @@
+package edu.pdx.cs410J.apptbook;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * A unit test for code in the <code>Project1</code> class.  This is different
+ * from {@link Project1IT} which is an integration test (and can handle the calls
+ * to {@link System#exit(int)} and the like.
+ */
+public class Project1Test {
+
+  @Test
+  public void readmeCanBeReadAsResource() throws IOException {
+    try (
+      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+    ) {
+      assertThat(readme, not(nullValue()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(readme));
+      String line = reader.readLine();
+      assertThat(line, containsString("This is a README file!"));
+    }
+  }
+}

--- a/projects-parent/originals-parent/phonebill/src/main/resources/edu/pdx/cs410J/phonebill/README.txt
+++ b/projects-parent/originals-parent/phonebill/src/main/resources/edu/pdx/cs410J/phonebill/README.txt
@@ -1,0 +1,1 @@
+This is a README file!

--- a/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/Project1Test.java
+++ b/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/Project1Test.java
@@ -1,0 +1,31 @@
+package edu.pdx.cs410J.phonebill;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * A unit test for code in the <code>Project1</code> class.  This is different
+ * from {@link Project1IT} which is an integration test (and can handle the calls
+ * to {@link System#exit(int)} and the like.
+ */
+public class Project1Test {
+
+  @Test
+  public void readmeCanBeReadAsResource() throws IOException {
+    try (
+      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+    ) {
+      assertThat(readme, not(nullValue()));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(readme));
+      String line = reader.readLine();
+      assertThat(line, containsString("This is a README file!"));
+    }
+  }
+}


### PR DESCRIPTION
Address issue #288 by adding an example of reading a README file as a resource.  I also modified the `Submit` program to only allow `.txt` and `.xml` files that reside in `resources` directories to be submitted.