### PR TITLE
Compile projects jar with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,10 +246,10 @@
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
           <fork>true</fork>
-          <compilerArgs>
-            <arg>--add-opens=java.base/java.lang=ALL-UNNAMED</arg>
-            <arg>--add-opens=java.base/java.util=ALL-UNNAMED</arg>
-          </compilerArgs>
+<!--          <compilerArgs>-->
+<!--            <arg>&#45;&#45;add-opens=java.base/java.lang=ALL-UNNAMED</arg>-->
+<!--            <arg>&#45;&#45;add-opens=java.base/java.util=ALL-UNNAMED</arg>-->
+<!--          </compilerArgs>-->
         </configuration>
         <executions>
           <execution>

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -37,6 +37,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Compile the project source using Java 8 so that it's compatible with Android projects -->
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgs></compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Compile the code for the projects (AbstractFlight, etc.) using Java 8 and get rid of the --add-opens, which we don't need in Java 11.