### PR TITLE
Issue 282 merge code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,15 +325,13 @@
             </execution>
             <execution>
               <id>default-report</id>
+              <phase>verify</phase>
               <goals>
                 <goal>report</goal>
               </goals>
-            </execution>
-            <execution>
-              <id>default-report-integration</id>
-              <goals>
-                <goal>report-integration</goal>
-              </goals>
+              <configuration>
+                <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
+              </configuration>
             </execution>
             <execution>
               <id>default-check</id>
@@ -343,6 +341,24 @@
               <configuration>
                 <rules>
                 </rules>
+              </configuration>
+            </execution>
+            <execution>
+              <id>merge-coverage-data</id>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>merge</goal>
+              </goals>
+              <configuration>
+                <fileSets>
+                  <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
+                    <directory>${project.build.directory}</directory>
+                    <includes>
+                      <include>jacoco*.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
               </configuration>
             </execution>
           </executions>
@@ -553,6 +569,9 @@
             </reports>
           </reportSet>
         </reportSets>
+        <configuration>
+          <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -185,24 +185,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -243,24 +243,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -186,24 +186,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -244,24 +244,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -174,24 +174,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -181,24 +181,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -244,24 +244,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -245,24 +245,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -185,24 +185,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -243,24 +243,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -185,24 +185,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -174,24 +174,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -243,24 +243,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -180,24 +180,6 @@
                   <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
-              <execution>
-                <id>merge-coverage-data</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>merge</goal>
-                </goals>
-                <configuration>
-                  <fileSets>
-                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>jacoco*.exec</include>
-                      </includes>
-                    </fileSet>
-                  </fileSets>
-                  <destFile>${project.build.directory}/jacoco-merged.exec</destFile>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
         </plugins>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -176,6 +176,7 @@
                       </limits>
                     </rule>
                   </rules>
+                  <dataFile>${project.build.directory}/jacoco-merged.exec</dataFile>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Continue to address #282 by configuring the projects to create a single JaCoCo report that contains code coverage for both unit and integration tests.