### PR TITLE
Update some dependencies in order to get code to work with Java 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - openjdk11
+  - openjdk14
 sudo: false
 script: "./mvnw install"

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -125,54 +125,6 @@
         </executions>
       </plugin>
         <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>webstart-maven-plugin</artifactId>
-            <version>1.0-beta-7</version>
-            <dependencies>
-              <dependency>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>keytool-api-1.7</artifactId>
-                <version>1.5</version>
-              </dependency>
-            </dependencies>
-            <executions>
-                <execution>
-                    <phase>install</phase>
-                    <goals>
-                        <goal>jnlp</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <jnlp>
-                    <outputFile>grader.jnlp</outputFile>
-                    <mainClass>edu.pdx.cs410J.grader.GradeBookGUI</mainClass>
-                </jnlp>
-                <!--
-                 defining this will automatically sign the jar and its dependencies
-                -->
-                <sign>
-                    <keystore>${java.io.tmpdir}${file.separator}keystore</keystore>
-                    <keypass>m2m2m2</keypass>
-                    <storepass>m2m2m2</storepass>
-                    <!--sigfile>m2m2m2</sigfile-->
-                    <alias>grader</alias>
-                    <validity>180</validity>
-                    <dnameCn>David Whitlock</dnameCn>
-                    <dnameO>Portland State University</dnameO>
-                    <dnameL>Portland</dnameL>
-                    <dnameSt>Oregon</dnameSt>
-                    <dnameC>US</dnameC>
-                    <verify>true</verify>
-                    <keystoreConfig>
-                        <delete>true</delete>
-                        <gen>true</gen>
-                    </keystoreConfig>
-                </sign>
-                <verbose>false</verbose>
-            </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <maven.compiler.source>10</maven.compiler.source>
         <maven.compiler.target>10</maven.compiler.target>
 
-        <groovy.version>3.0.0-beta-1</groovy.version>
+        <groovy.version>3.0.4</groovy.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -77,6 +77,11 @@
         <id>CS410J</id>
         <name>CS410J Maven Repository</name>
         <url>https://dl.bintray.com/davidwhitlock/maven</url>
+      </repository>
+      <repository>
+        <id>jcenter</id>
+        <name>bintray</name>
+        <url>https://jcenter.bintray.com</url>
       </repository>
     </repositories>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.4</version>
+          <version>0.8.5</version>
           <executions>
             <execution>
               <id>default-prepare-agent</id>


### PR DESCRIPTION
Java 14 is out and several student have started to use it.  However, they encountered problem when they did.  These changes get the code for the course working with Java 14.  This is related to #249.