### PR TITLE
Test classes and methods have default visibility

### DIFF
--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/it/java/Project1IT.java
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Integration tests for the {@link Project1} main class.
  */
-public class Project1IT extends InvokeMainTestCase {
+class Project1IT extends InvokeMainTestCase {
 
   /**
    * Invokes the main method of {@link Project1} with the given arguments.
@@ -26,7 +26,7 @@ public class Project1IT extends InvokeMainTestCase {
    * Tests that invoking the main method with no arguments issues an error
    */
   @Test
-  public void testNoCommandLineArguments() {
+  void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentTest.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentTest.java
@@ -1,6 +1,6 @@
-#set($symbol_pound='#')
-#set($symbol_dollar='$')
-#set($symbol_escape='\' )
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
 package ${package};
 
 import org.junit.jupiter.api.Test;
@@ -17,19 +17,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class AppointmentTest {
 
   @Test
-  public void getBeginTimeStringNeedsToBeImplemented() {
+  void getBeginTimeStringNeedsToBeImplemented() {
     Appointment appointment = new Appointment();
     assertThrows(UnsupportedOperationException.class, appointment::getBeginTimeString);
   }
 
   @Test
-  public void initiallyAllAppointmentsHaveTheSameDescription() {
+  void initiallyAllAppointmentsHaveTheSameDescription() {
     Appointment appointment = new Appointment();
     assertThat(appointment.getDescription(), containsString("not implemented"));
   }
 
   @Test
-  public void forProject1ItIsOkayIfGetBeginTimeReturnsNull() {
+  void forProject1ItIsOkayIfGetBeginTimeReturnsNull() {
     Appointment appointment = new Appointment();
     assertThat(appointment.getBeginTime(), is(nullValue()));
   }

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/java/Project1Test.java
@@ -18,12 +18,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * from <code>Project1IT</code> which is an integration test (and can handle the calls
  * to {@link System${symbol_pound}exit(int)} and the like.
  */
-public class Project1Test {
+class Project1Test {
 
   @Test
-  public void readmeCanBeReadAsResource() throws IOException {
+  void readmeCanBeReadAsResource() throws IOException {
     try (
-      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+      InputStream readme = Project1.class.getResourceAsStream("README.txt")
     ) {
       assertThat(readme, not(nullValue()));
       BufferedReader reader = new BufferedReader(new InputStreamReader(readme));

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Integration test that tests the REST calls made by {@link AppointmentBookRestClient}
  */
 @TestMethodOrder(MethodName.class)
-public class AppointmentBookRestClientIT {
+class AppointmentBookRestClientIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
@@ -30,20 +30,20 @@ public class AppointmentBookRestClientIT {
   }
 
   @Test
-  public void test0RemoveAllDictionaryEntries() throws IOException {
+  void test0RemoveAllDictionaryEntries() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     client.removeAllDictionaryEntries();
   }
 
   @Test
-  public void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
+  void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     Map<String, String> dictionary = client.getAllDictionaryEntries();
     assertThat(dictionary.size(), equalTo(0));
   }
 
   @Test
-  public void test2DefineOneWord() throws IOException {
+  void test2DefineOneWord() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     String testWord = "TEST WORD";
     String testDefinition = "TEST DEFINITION";
@@ -54,7 +54,7 @@ public class AppointmentBookRestClientIT {
   }
 
   @Test
-  public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
+  void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/IndexDotHtmlIT.java
@@ -14,18 +14,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class IndexDotHtmlIT {
+class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
   @Test
-  public void indexDotHtmlExists() throws IOException {
+  void indexDotHtmlExists() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getCode(), equalTo(200));
   }
 
   @Test
-  public void indexDotHtmlHasResonableContent() throws IOException {
+  void indexDotHtmlHasReasonableContent() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
@@ -43,7 +43,7 @@ public class IndexDotHtmlIT {
       this.url = String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" );
     }
 
-    public Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return get(this.url, Map.of());
     }
   }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -23,25 +23,25 @@ import static org.junit.jupiter.api.Assertions.fail;
  * various arguments
  */
 @TestMethodOrder(MethodName.class)
-public class Project4IT extends InvokeMainTestCase {
+class Project4IT extends InvokeMainTestCase {
     private static final String HOSTNAME = "localhost";
     private static final String PORT = System.getProperty("http.port", "8080");
 
     @Test
-    public void test0RemoveAllMappings() throws IOException {
+    void test0RemoveAllMappings() throws IOException {
       AppointmentBookRestClient client = new AppointmentBookRestClient(HOSTNAME, Integer.parseInt(PORT));
       client.removeAllDictionaryEntries();
     }
 
     @Test
-    public void test1NoCommandLineArguments() {
+    void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
         assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
-    public void test2EmptyServer() {
+    void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
         assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
         String out = result.getTextWrittenToStandardOut();
@@ -49,7 +49,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test3NoDefinitionsThrowsAppointmentBookRestException() throws Throwable {
+    void test3NoDefinitionsThrowsAppointmentBookRestException() {
         String word = "WORD";
         try {
             invokeMain(Project4.class, HOSTNAME, PORT, word);
@@ -62,7 +62,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test4AddDefinition() {
+    void test4AddDefinition() {
         String word = "WORD";
         String definition = "DEFINITION";
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 public class AppointmentBookServletTest {
 
   @Test
-  public void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
+  void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
     AppointmentBookServlet servlet = new AppointmentBookServlet();
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -42,7 +42,7 @@ public class AppointmentBookServletTest {
   }
 
   @Test
-  public void addOneWordToDictionary() throws ServletException, IOException {
+  void addOneWordToDictionary() throws ServletException, IOException {
     AppointmentBookServlet servlet = new AppointmentBookServlet();
 
     String word = "TEST WORD";

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/MessagesTest.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/MessagesTest.java
@@ -11,50 +11,51 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
-public class MessagesTest {
+class MessagesTest {
 
   @Test
-  public void malformedWordAndDefinitionReturnsNull() {
+  void malformedWordAndDefinitionReturnsNull() {
     assertThat(Messages.parseDictionaryEntry("blah"), nullValue());
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryPair() {
+  void canParseFormattedDictionaryEntryPair() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
+  void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     String trimmed = formatted.trim();
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(trimmed);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
 
   }
 
   @Test
-  public void nullDefinitionIsParsedAsNull() {
+  void nullDefinitionIsParsedAsNull() {
     String word = "testWord";
-    String definition = null;
-    String formatted = Messages.formatDictionaryEntry(word, definition);
+    String formatted = Messages.formatDictionaryEntry(word, null);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
-    assertThat(parsed.getValue(), equalTo(definition));
+    assertThat(parsed.getValue(), equalTo(null));
   }
 
   @Test
-  public void canParseFormattedDictionary() {
+  void canParseFormattedDictionary() {
     Map<String, String> dictionary = new HashMap<>();
 
     for (int i = 0; i < 5; i++) {

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/it/java/KataIT.java
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/it/java/KataIT.java
@@ -10,16 +10,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
-public class KataIT extends InvokeMainTestCase {
+class KataIT extends InvokeMainTestCase {
 
   @Test
-  public void invokingMainWithNoArgumentsHasExitCodeOf1() {
+  void invokingMainWithNoArgumentsHasExitCodeOf1() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Kata.class);
     assertThat(result.getExitCode(), equalTo(1));
   }
 
   @Test
-  public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
+  void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Kata.class);
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/test/java/KataTest.java
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/test/java/KataTest.java
@@ -9,7 +9,7 @@ public class KataTest
 {
 
   @Test
-  public void canInstantiateKataClass() {
+  void canInstantiateKataClass() {
     new Kata();
   }
 

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/it/java/StudentIT.java
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/it/java/StudentIT.java
@@ -15,18 +15,18 @@ import static org.hamcrest.core.StringContains.containsString;
  * These tests extend <code>InvokeMainTestCase</code> which allows them
  * to easily invoke the <code>main</code> method of <code>Student</code>.
  */
-public class StudentIT extends InvokeMainTestCase {
+class StudentIT extends InvokeMainTestCase {
+
   @Test
-  public void invokingMainWithNoArgumentsHasExitCodeOf1() {
+  void invokingMainWithNoArgumentsHasExitCodeOf1() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
     assertThat(result.getExitCode(), equalTo(1));
   }
 
   @Test
-  public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
+  void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
-
 
 }

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/test/java/StudentTest.java
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/test/java/StudentTest.java
@@ -19,7 +19,7 @@ public class StudentTest
 {
 
   @Test
-  public void studentNamedPatIsNamedPat() {
+  void studentNamedPatIsNamedPat() {
     String name = "Pat";
     var pat = new Student(name, new ArrayList<>(), 0.0, "Doesn't matter");
     assertThat(pat.getName(), equalTo(name));

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Integration test that tests the REST calls made by {@link AirlineRestClient}
  */
 @TestMethodOrder(MethodName.class)
-public class AirlineRestClientIT {
+class AirlineRestClientIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
@@ -27,20 +27,20 @@ public class AirlineRestClientIT {
   }
 
   @Test
-  public void test0RemoveAllDictionaryEntries() throws IOException {
+  void test0RemoveAllDictionaryEntries() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
     client.removeAllDictionaryEntries();
   }
 
   @Test
-  public void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
+  void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
     Map<String, String> dictionary = client.getAllDictionaryEntries();
     assertThat(dictionary.size(), equalTo(0));
   }
 
   @Test
-  public void test2DefineOneWord() throws IOException {
+  void test2DefineOneWord() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
     String testWord = "TEST WORD";
     String testDefinition = "TEST DEFINITION";
@@ -51,7 +51,7 @@ public class AirlineRestClientIT {
   }
 
   @Test
-  public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
+  void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AirlineRestClient client = newAirlineRestClient();
     HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/IndexDotHtmlIT.java
@@ -11,18 +11,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class IndexDotHtmlIT {
+class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
   @Test
-  public void indexDotHtmlExists() throws IOException {
+  void indexDotHtmlExists() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getCode(), equalTo(200));
   }
 
   @Test
-  public void indexDotHtmlHasResonableContent() throws IOException {
+  void indexDotHtmlHasReasonableContent() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
@@ -40,7 +40,7 @@ public class IndexDotHtmlIT {
       this.url = String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" );
     }
 
-    public Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return get(this.url, Map.of());
     }
   }

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project5IT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project5IT.java
@@ -20,25 +20,25 @@ import static org.junit.jupiter.api.MethodOrderer.MethodName;
  * various arguments
  */
 @TestMethodOrder(MethodName.class)
-public class Project5IT extends InvokeMainTestCase {
+class Project5IT extends InvokeMainTestCase {
     private static final String HOSTNAME = "localhost";
     private static final String PORT = System.getProperty("http.port", "8080");
 
     @Test
-    public void test0RemoveAllMappings() throws IOException {
+    void test0RemoveAllMappings() throws IOException {
       AirlineRestClient client = new AirlineRestClient(HOSTNAME, Integer.parseInt(PORT));
       client.removeAllDictionaryEntries();
     }
 
     @Test
-    public void test1NoCommandLineArguments() {
+    void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project5.class );
         assertThat(result.getExitCode(), equalTo(1));
         assertThat(result.getTextWrittenToStandardError(), containsString(Project5.MISSING_ARGS));
     }
 
     @Test
-    public void test2EmptyServer() {
+    void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project5.class, HOSTNAME, PORT );
         assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
         String out = result.getTextWrittenToStandardOut();
@@ -46,7 +46,7 @@ public class Project5IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test3NoDefinitionsThrowsAppointmentBookRestException() throws Throwable {
+    void test3NoDefinitionsThrowsAppointmentBookRestException() {
         String word = "WORD";
         try {
             invokeMain(Project5.class, HOSTNAME, PORT, word);
@@ -59,7 +59,7 @@ public class Project5IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test4AddDefinition() {
+    void test4AddDefinition() {
         String word = "WORD";
         String definition = "DEFINITION";
 

--- a/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/AirlineServletTest.java
+++ b/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/AirlineServletTest.java
@@ -19,10 +19,10 @@ import static org.mockito.Mockito.*;
  * A unit test for the {@link AirlineServlet}.  It uses mockito to
  * provide mock http requests and responses.
  */
-public class AirlineServletTest {
+class AirlineServletTest {
 
   @Test
-  public void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
+  void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
     AirlineServlet servlet = new AirlineServlet();
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -39,7 +39,7 @@ public class AirlineServletTest {
   }
 
   @Test
-  public void addOneWordToDictionary() throws ServletException, IOException {
+  void addOneWordToDictionary() throws ServletException, IOException {
     AirlineServlet servlet = new AirlineServlet();
 
     String word = "TEST WORD";

--- a/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/MessagesTest.java
+++ b/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/MessagesTest.java
@@ -8,50 +8,51 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
-public class MessagesTest {
+class MessagesTest {
 
   @Test
-  public void malformedWordAndDefinitionReturnsNull() {
+  void malformedWordAndDefinitionReturnsNull() {
     assertThat(Messages.parseDictionaryEntry("blah"), nullValue());
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryPair() {
+  void canParseFormattedDictionaryEntryPair() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
+  void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     String trimmed = formatted.trim();
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(trimmed);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
 
   }
 
   @Test
-  public void nullDefinitionIsParsedAsNull() {
+  void nullDefinitionIsParsedAsNull() {
     String word = "testWord";
-    String definition = null;
-    String formatted = Messages.formatDictionaryEntry(word, definition);
+    String formatted = Messages.formatDictionaryEntry(word, null);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
-    assertThat(parsed.getValue(), equalTo(definition));
+    assertThat(parsed.getValue(), equalTo(null));
   }
 
   @Test
-  public void canParseFormattedDictionary() {
+  void canParseFormattedDictionary() {
     Map<String, String> dictionary = new HashMap<>();
 
     for (int i = 0; i < 5; i++) {

--- a/projects-parent/originals-parent/airline/src/it/java/edu/pdx/cs410J/airline/Project1IT.java
+++ b/projects-parent/originals-parent/airline/src/it/java/edu/pdx/cs410J/airline/Project1IT.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * An integration test for the {@link Project1} main class.
  */
-public class Project1IT extends InvokeMainTestCase {
+class Project1IT extends InvokeMainTestCase {
 
     /**
      * Invokes the main method of {@link Project1} with the given arguments.
@@ -23,7 +23,7 @@ public class Project1IT extends InvokeMainTestCase {
    * Tests that invoking the main method with no arguments issues an error
    */
   @Test
-  public void testNoCommandLineArguments() {
+  void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));

--- a/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/AirlineXmlHelperTest.java
+++ b/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/AirlineXmlHelperTest.java
@@ -11,10 +11,10 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class AirlineXmlHelperTest {
+class AirlineXmlHelperTest {
 
   @Test
-  public void canParseValidXmlFile() throws ParserConfigurationException, IOException, SAXException {
+  void canParseValidXmlFile() throws ParserConfigurationException, IOException, SAXException {
     AirlineXmlHelper helper = new AirlineXmlHelper();
 
 
@@ -31,7 +31,7 @@ public class AirlineXmlHelperTest {
   }
 
   @Test
-  public void cantParseInvalidXmlFile() throws ParserConfigurationException, IOException, SAXException {
+  void cantParseInvalidXmlFile() throws ParserConfigurationException {
     AirlineXmlHelper helper = new AirlineXmlHelper();
 
 

--- a/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/FlightTest.java
+++ b/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/FlightTest.java
@@ -11,22 +11,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out you program.
  */
-public class FlightTest {
+class FlightTest {
   
   @Test
-  public void getArrivalStringNeedsToBeImplemented() {
+  void getArrivalStringNeedsToBeImplemented() {
     Flight flight = new Flight();
     assertThrows(UnsupportedOperationException.class, flight::getArrivalString);
   }
 
   @Test
-  public void initiallyAllFlightsHaveTheSameNumber() {
+  void initiallyAllFlightsHaveTheSameNumber() {
     Flight flight = new Flight();
     assertThat(flight.getNumber(), equalTo(42));
   }
 
   @Test
-  public void forProject1ItIsOkayIfGetDepartureTimeReturnsNull() {
+  void forProject1ItIsOkayIfGetDepartureTimeReturnsNull() {
     Flight flight = new Flight();
     assertThat(flight.getDeparture(), is(nullValue()));
   }

--- a/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/FlightTest.java
+++ b/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/FlightTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out you program.
  */
-class FlightTest {
+public class FlightTest {
   
   @Test
   void getArrivalStringNeedsToBeImplemented() {

--- a/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/Project1Test.java
+++ b/projects-parent/originals-parent/airline/src/test/java/edu/pdx/cs410J/airline/Project1Test.java
@@ -15,12 +15,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * from <code>Project1IT</code> which is an integration test (and can handle the calls
  * to {@link System#exit(int)} and the like.
  */
-public class Project1Test {
+class Project1Test {
 
   @Test
-  public void readmeCanBeReadAsResource() throws IOException {
+  void readmeCanBeReadAsResource() throws IOException {
     try (
-      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+      InputStream readme = Project1.class.getResourceAsStream("README.txt")
     ) {
       assertThat(readme, not(nullValue()));
       BufferedReader reader = new BufferedReader(new InputStreamReader(readme));

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Integration test that tests the REST calls made by {@link AppointmentBookRestClient}
  */
 @TestMethodOrder(MethodName.class)
-public class AppointmentBookRestClientIT {
+class AppointmentBookRestClientIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
@@ -27,20 +27,20 @@ public class AppointmentBookRestClientIT {
   }
 
   @Test
-  public void test0RemoveAllDictionaryEntries() throws IOException {
+  void test0RemoveAllDictionaryEntries() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     client.removeAllDictionaryEntries();
   }
 
   @Test
-  public void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
+  void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     Map<String, String> dictionary = client.getAllDictionaryEntries();
     assertThat(dictionary.size(), equalTo(0));
   }
 
   @Test
-  public void test2DefineOneWord() throws IOException {
+  void test2DefineOneWord() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     String testWord = "TEST WORD";
     String testDefinition = "TEST DEFINITION";
@@ -51,7 +51,7 @@ public class AppointmentBookRestClientIT {
   }
 
   @Test
-  public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
+  void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/IndexDotHtmlIT.java
@@ -11,18 +11,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class IndexDotHtmlIT {
+class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
   @Test
-  public void indexDotHtmlExists() throws IOException {
+  void indexDotHtmlExists() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getCode(), equalTo(200));
   }
 
   @Test
-  public void indexDotHtmlHasResonableContent() throws IOException {
+  void indexDotHtmlHasReasonableContent() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
@@ -40,7 +40,7 @@ public class IndexDotHtmlIT {
       this.url = String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" );
     }
 
-    public Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return get(this.url, Map.of());
     }
   }

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
@@ -20,25 +20,25 @@ import static org.junit.jupiter.api.Assertions.fail;
  * various arguments
  */
 @TestMethodOrder(MethodName.class)
-public class Project4IT extends InvokeMainTestCase {
+class Project4IT extends InvokeMainTestCase {
     private static final String HOSTNAME = "localhost";
     private static final String PORT = System.getProperty("http.port", "8080");
 
     @Test
-    public void test0RemoveAllMappings() throws IOException {
+    void test0RemoveAllMappings() throws IOException {
       AppointmentBookRestClient client = new AppointmentBookRestClient(HOSTNAME, Integer.parseInt(PORT));
       client.removeAllDictionaryEntries();
     }
 
     @Test
-    public void test1NoCommandLineArguments() {
+    void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
         assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
-    public void test2EmptyServer() {
+    void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
         assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
         String out = result.getTextWrittenToStandardOut();
@@ -46,7 +46,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test3NoDefinitionsThrowsAppointmentBookRestException() throws Throwable {
+    void test3NoDefinitionsThrowsAppointmentBookRestException() {
         String word = "WORD";
         try {
             invokeMain(Project4.class, HOSTNAME, PORT, word);
@@ -59,7 +59,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test4AddDefinition() {
+    void test4AddDefinition() {
         String word = "WORD";
         String definition = "DEFINITION";
 

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.*;
  * A unit test for the {@link AppointmentBookServlet}.  It uses mockito to
  * provide mock http requests and responses.
  */
-class AppointmentBookServletTest {
+public class AppointmentBookServletTest {
 
   @Test
   void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
@@ -19,10 +19,10 @@ import static org.mockito.Mockito.*;
  * A unit test for the {@link AppointmentBookServlet}.  It uses mockito to
  * provide mock http requests and responses.
  */
-public class AppointmentBookServletTest {
+class AppointmentBookServletTest {
 
   @Test
-  public void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
+  void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
     AppointmentBookServlet servlet = new AppointmentBookServlet();
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -39,7 +39,7 @@ public class AppointmentBookServletTest {
   }
 
   @Test
-  public void addOneWordToDictionary() throws ServletException, IOException {
+  void addOneWordToDictionary() throws ServletException, IOException {
     AppointmentBookServlet servlet = new AppointmentBookServlet();
 
     String word = "TEST WORD";

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/MessagesTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/MessagesTest.java
@@ -8,50 +8,51 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
-public class MessagesTest {
+class MessagesTest {
 
   @Test
-  public void malformedWordAndDefinitionReturnsNull() {
+  void malformedWordAndDefinitionReturnsNull() {
     assertThat(Messages.parseDictionaryEntry("blah"), nullValue());
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryPair() {
+  void canParseFormattedDictionaryEntryPair() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
+  void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     String trimmed = formatted.trim();
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(trimmed);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
 
   }
 
   @Test
-  public void nullDefinitionIsParsedAsNull() {
+  void nullDefinitionIsParsedAsNull() {
     String word = "testWord";
-    String definition = null;
-    String formatted = Messages.formatDictionaryEntry(word, definition);
+    String formatted = Messages.formatDictionaryEntry(word, null);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
-    assertThat(parsed.getValue(), equalTo(definition));
+    assertThat(parsed.getValue(), equalTo(null));
   }
 
   @Test
-  public void canParseFormattedDictionary() {
+  void canParseFormattedDictionary() {
     Map<String, String> dictionary = new HashMap<>();
 
     for (int i = 0; i < 5; i++) {

--- a/projects-parent/originals-parent/apptbook/src/it/java/edu/pdx/cs410J/apptbook/Project1IT.java
+++ b/projects-parent/originals-parent/apptbook/src/it/java/edu/pdx/cs410J/apptbook/Project1IT.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Integration tests for the {@link Project1} main class.
  */
-public class Project1IT extends InvokeMainTestCase {
+class Project1IT extends InvokeMainTestCase {
 
   /**
    * Invokes the main method of {@link Project1} with the given arguments.
@@ -23,7 +23,7 @@ public class Project1IT extends InvokeMainTestCase {
    * Tests that invoking the main method with no arguments issues an error
    */
   @Test
-  public void testNoCommandLineArguments() {
+  void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));

--- a/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/AppointmentTest.java
+++ b/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/AppointmentTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out your program.
  */
-class AppointmentTest {
+public class AppointmentTest {
 
   @Test
   void getBeginTimeStringNeedsToBeImplemented() {

--- a/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/AppointmentTest.java
+++ b/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/AppointmentTest.java
@@ -11,22 +11,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out your program.
  */
-public class AppointmentTest {
+class AppointmentTest {
 
   @Test
-  public void getBeginTimeStringNeedsToBeImplemented() {
+  void getBeginTimeStringNeedsToBeImplemented() {
     Appointment appointment = new Appointment();
     assertThrows(UnsupportedOperationException.class, appointment::getBeginTimeString);
   }
 
   @Test
-  public void initiallyAllAppointmentsHaveTheSameDescription() {
+  void initiallyAllAppointmentsHaveTheSameDescription() {
     Appointment appointment = new Appointment();
     assertThat(appointment.getDescription(), containsString("not implemented"));
   }
 
   @Test
-  public void forProject1ItIsOkayIfGetBeginTimeReturnsNull() {
+  void forProject1ItIsOkayIfGetBeginTimeReturnsNull() {
     Appointment appointment = new Appointment();
     assertThat(appointment.getBeginTime(), is(nullValue()));
   }

--- a/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/Project1Test.java
+++ b/projects-parent/originals-parent/apptbook/src/test/java/edu/pdx/cs410J/apptbook/Project1Test.java
@@ -15,12 +15,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * from <code>Project1IT</code> which is an integration test (and can handle the calls
  * to {@link System#exit(int)} and the like.
  */
-public class Project1Test {
+class Project1Test {
 
   @Test
-  public void readmeCanBeReadAsResource() throws IOException {
+  void readmeCanBeReadAsResource() throws IOException {
     try (
-      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+      InputStream readme = Project1.class.getResourceAsStream("README.txt")
     ) {
       assertThat(readme, not(nullValue()));
       BufferedReader reader = new BufferedReader(new InputStreamReader(readme));

--- a/projects-parent/originals-parent/kata/src/it/java/edu/pdx/cs410J/kata/KataIT.java
+++ b/projects-parent/originals-parent/kata/src/it/java/edu/pdx/cs410J/kata/KataIT.java
@@ -7,16 +7,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 
-public class KataIT extends InvokeMainTestCase {
+class KataIT extends InvokeMainTestCase {
 
   @Test
-  public void invokingMainWithNoArgumentsHasExitCodeOf1() {
+  void invokingMainWithNoArgumentsHasExitCodeOf1() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Kata.class);
     assertThat(result.getExitCode(), equalTo(1));
   }
 
   @Test
-  public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
+  void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Kata.class);
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }

--- a/projects-parent/originals-parent/kata/src/test/java/edu/pdx/cs410J/kata/KataTest.java
+++ b/projects-parent/originals-parent/kata/src/test/java/edu/pdx/cs410J/kata/KataTest.java
@@ -2,11 +2,11 @@ package edu.pdx.cs410J.kata;
 
 import org.junit.jupiter.api.Test;
 
-public class KataTest
+class KataTest
 {
 
   @Test
-  public void canInstantiateKataClass() {
+  void canInstantiateKataClass() {
     new Kata();
   }
 

--- a/projects-parent/originals-parent/kata/src/test/java/edu/pdx/cs410J/kata/KataTest.java
+++ b/projects-parent/originals-parent/kata/src/test/java/edu/pdx/cs410J/kata/KataTest.java
@@ -2,7 +2,7 @@ package edu.pdx.cs410J.kata;
 
 import org.junit.jupiter.api.Test;
 
-class KataTest
+public class KataTest
 {
 
   @Test

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/IndexDotHtmlIT.java
@@ -11,18 +11,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class IndexDotHtmlIT {
+class IndexDotHtmlIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
   @Test
-  public void indexDotHtmlExists() throws IOException {
+  void indexDotHtmlExists() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getCode(), equalTo(200));
   }
 
   @Test
-  public void indexDotHtmlHasResonableContent() throws IOException {
+  void indexDotHtmlHasReasonableContent() throws IOException {
     Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
@@ -40,7 +40,7 @@ public class IndexDotHtmlIT {
       this.url = String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" );
     }
 
-    public Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return get(this.url, Map.of());
     }
   }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Integration test that tests the REST calls made by {@link PhoneBillRestClient}
  */
 @TestMethodOrder(MethodName.class)
-public class PhoneBillRestClientIT {
+class PhoneBillRestClientIT {
   private static final String HOSTNAME = "localhost";
   private static final String PORT = System.getProperty("http.port", "8080");
 
@@ -27,20 +27,20 @@ public class PhoneBillRestClientIT {
   }
 
   @Test
-  public void test0RemoveAllDictionaryEntries() throws IOException {
+  void test0RemoveAllDictionaryEntries() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
     client.removeAllDictionaryEntries();
   }
 
   @Test
-  public void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
+  void test1EmptyServerContainsNoDictionaryEntries() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
     Map<String, String> dictionary = client.getAllDictionaryEntries();
     assertThat(dictionary.size(), equalTo(0));
   }
 
   @Test
-  public void test2DefineOneWord() throws IOException {
+  void test2DefineOneWord() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
     String testWord = "TEST WORD";
     String testDefinition = "TEST DEFINITION";
@@ -51,7 +51,7 @@ public class PhoneBillRestClientIT {
   }
 
   @Test
-  public void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
+  void test4MissingRequiredParameterReturnsPreconditionFailed() throws IOException {
     PhoneBillRestClient client = newPhoneBillRestClient();
     HttpRequestHelper.Response response = client.postToMyURL(Map.of());
     assertThat(response.getContent(), containsString(Messages.missingRequiredParameter("word")));

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
@@ -19,25 +19,25 @@ import static org.junit.jupiter.api.MethodOrderer.MethodName;
  * Tests the {@link Project4} class by invoking its main method with various arguments
  */
 @TestMethodOrder(MethodName.class)
-public class Project4IT extends InvokeMainTestCase {
+class Project4IT extends InvokeMainTestCase {
     private static final String HOSTNAME = "localhost";
     private static final String PORT = System.getProperty("http.port", "8080");
 
     @Test
-    public void test0RemoveAllMappings() throws IOException {
+    void test0RemoveAllMappings() throws IOException {
       PhoneBillRestClient client = new PhoneBillRestClient(HOSTNAME, Integer.parseInt(PORT));
       client.removeAllDictionaryEntries();
     }
 
     @Test
-    public void test1NoCommandLineArguments() {
+    void test1NoCommandLineArguments() {
         MainMethodResult result = invokeMain( Project4.class );
         assertThat(result.getExitCode(), equalTo(1));
         assertThat(result.getTextWrittenToStandardError(), containsString(Project4.MISSING_ARGS));
     }
 
     @Test
-    public void test2EmptyServer() {
+    void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
         assertThat(result.getTextWrittenToStandardError(), result.getExitCode(), equalTo(0));
         String out = result.getTextWrittenToStandardOut();
@@ -45,7 +45,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test3NoDefinitionsThrowsAppointmentBookRestException() throws Throwable {
+    void test3NoDefinitionsThrowsAppointmentBookRestException() {
         String word = "WORD";
         try {
             invokeMain(Project4.class, HOSTNAME, PORT, word);
@@ -58,7 +58,7 @@ public class Project4IT extends InvokeMainTestCase {
     }
 
     @Test
-    public void test4AddDefinition() {
+    void test4AddDefinition() {
         String word = "WORD";
         String definition = "DEFINITION";
 

--- a/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/MessagesTest.java
+++ b/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/MessagesTest.java
@@ -8,50 +8,51 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
-public class MessagesTest {
+class MessagesTest {
 
   @Test
-  public void malformedWordAndDefinitionReturnsNull() {
+  void malformedWordAndDefinitionReturnsNull() {
     assertThat(Messages.parseDictionaryEntry("blah"), nullValue());
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryPair() {
+  void canParseFormattedDictionaryEntryPair() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
   }
 
   @Test
-  public void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
+  void canParseFormattedDictionaryEntryWithoutLeadingSpaces() {
     String word = "testWord";
     String definition = "testDefinition";
     String formatted = Messages.formatDictionaryEntry(word, definition);
     String trimmed = formatted.trim();
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(trimmed);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
     assertThat(parsed.getValue(), equalTo(definition));
 
   }
 
   @Test
-  public void nullDefinitionIsParsedAsNull() {
+  void nullDefinitionIsParsedAsNull() {
     String word = "testWord";
-    String definition = null;
-    String formatted = Messages.formatDictionaryEntry(word, definition);
+    String formatted = Messages.formatDictionaryEntry(word, null);
     Map.Entry<String, String> parsed = Messages.parseDictionaryEntry(formatted);
+    assertThat(parsed, notNullValue());
     assertThat(parsed.getKey(), equalTo(word));
-    assertThat(parsed.getValue(), equalTo(definition));
+    assertThat(parsed.getValue(), equalTo(null));
   }
 
   @Test
-  public void canParseFormattedDictionary() {
+  void canParseFormattedDictionary() {
     Map<String, String> dictionary = new HashMap<>();
 
     for (int i = 0; i < 5; i++) {

--- a/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/PhoneBillServletTest.java
+++ b/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/PhoneBillServletTest.java
@@ -19,10 +19,10 @@ import static org.mockito.Mockito.*;
  * A unit test for the {@link PhoneBillServlet}.  It uses mockito to
  * provide mock http requests and responses.
  */
-public class PhoneBillServletTest {
+class PhoneBillServletTest {
 
   @Test
-  public void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
+  void initiallyServletContainsNoDictionaryEntries() throws ServletException, IOException {
     PhoneBillServlet servlet = new PhoneBillServlet();
 
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -39,7 +39,7 @@ public class PhoneBillServletTest {
   }
 
   @Test
-  public void addOneWordToDictionary() throws ServletException, IOException {
+  void addOneWordToDictionary() throws ServletException, IOException {
     PhoneBillServlet servlet = new PhoneBillServlet();
 
     String word = "TEST WORD";

--- a/projects-parent/originals-parent/phonebill/src/it/java/edu/pdx/cs410J/phonebill/Project1IT.java
+++ b/projects-parent/originals-parent/phonebill/src/it/java/edu/pdx/cs410J/phonebill/Project1IT.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Tests the functionality in the {@link Project1} main class.
  */
-public class Project1IT extends InvokeMainTestCase {
+class Project1IT extends InvokeMainTestCase {
 
     /**
      * Invokes the main method of {@link Project1} with the given arguments.
@@ -23,7 +23,7 @@ public class Project1IT extends InvokeMainTestCase {
    * Tests that invoking the main method with no arguments issues an error
    */
   @Test
-  public void testNoCommandLineArguments() {
+  void testNoCommandLineArguments() {
     MainMethodResult result = invokeMain();
     assertThat(result.getExitCode(), equalTo(1));
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));

--- a/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/PhoneCallTest.java
+++ b/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/PhoneCallTest.java
@@ -11,22 +11,22 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out your program.
  */
-public class PhoneCallTest {
+class PhoneCallTest {
 
   @Test
-  public void getStartTimeStringNeedsToBeImplemented() {
+  void getStartTimeStringNeedsToBeImplemented() {
     PhoneCall call = new PhoneCall();
     assertThrows(UnsupportedOperationException.class, call::getStartTimeString);
   }
 
   @Test
-  public void initiallyAllPhoneCallsHaveTheSameCallee() {
+  void initiallyAllPhoneCallsHaveTheSameCallee() {
     PhoneCall call = new PhoneCall();
     assertThat(call.getCallee(), containsString("not implemented"));
   }
 
   @Test
-  public void forProject1ItIsOkayIfGetStartTimeReturnsNull() {
+  void forProject1ItIsOkayIfGetStartTimeReturnsNull() {
     PhoneCall call = new PhoneCall();
     assertThat(call.getStartTime(), is(nullValue()));
   }

--- a/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/PhoneCallTest.java
+++ b/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/PhoneCallTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * You'll need to update these unit tests as you build out your program.
  */
-class PhoneCallTest {
+public class PhoneCallTest {
 
   @Test
   void getStartTimeStringNeedsToBeImplemented() {

--- a/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/Project1Test.java
+++ b/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/Project1Test.java
@@ -15,12 +15,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * from <code>Project1IT</code> which is an integration test (and can handle the calls
  * to {@link System#exit(int)} and the like.
  */
-public class Project1Test {
+class Project1Test {
 
   @Test
-  public void readmeCanBeReadAsResource() throws IOException {
+  void readmeCanBeReadAsResource() throws IOException {
     try (
-      InputStream readme = Project1.class.getResourceAsStream("README.txt");
+      InputStream readme = Project1.class.getResourceAsStream("README.txt")
     ) {
       assertThat(readme, not(nullValue()));
       BufferedReader reader = new BufferedReader(new InputStreamReader(readme));

--- a/projects-parent/originals-parent/student/src/it/java/edu/pdx/cs410J/student/StudentIT.java
+++ b/projects-parent/originals-parent/student/src/it/java/edu/pdx/cs410J/student/StudentIT.java
@@ -12,18 +12,18 @@ import static org.hamcrest.core.StringContains.containsString;
  * These tests extend <code>InvokeMainTestCase</code> which allows them
  * to easily invoke the <code>main</code> method of <code>Student</code>.
  */
-public class StudentIT extends InvokeMainTestCase {
+class StudentIT extends InvokeMainTestCase {
+
   @Test
-  public void invokingMainWithNoArgumentsHasExitCodeOf1() {
+  void invokingMainWithNoArgumentsHasExitCodeOf1() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
     assertThat(result.getExitCode(), equalTo(1));
   }
 
   @Test
-  public void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
+  void invokingMainWithNoArgumentsPrintsMissingArgumentsToStandardError() {
     InvokeMainTestCase.MainMethodResult result = invokeMain(Student.class);
     assertThat(result.getTextWrittenToStandardError(), containsString("Missing command line arguments"));
   }
-
 
 }

--- a/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
+++ b/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * they also make use of the <a href="http://hamcrest.org/JavaHamcrest/">hamcrest</a>
  * matchers for more readable assertion statements.
  */
-class StudentTest
+public class StudentTest
 {
 
   @Test

--- a/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
+++ b/projects-parent/originals-parent/student/src/test/java/edu/pdx/cs410J/student/StudentTest.java
@@ -12,11 +12,11 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * they also make use of the <a href="http://hamcrest.org/JavaHamcrest/">hamcrest</a>
  * matchers for more readable assertion statements.
  */
-public class StudentTest
+class StudentTest
 {
 
   @Test
-  public void studentNamedPatIsNamedPat() {
+  void studentNamedPatIsNamedPat() {
     String name = "Pat";
     var pat = new Student(name, new ArrayList<>(), 0.0, "Doesn't matter");
     assertThat(pat.getName(), equalTo(name));


### PR DESCRIPTION
JUnit 5 no longer requires public classes and methods.  Remove "public" modifier from JUnit tests in original projects.  Also, removed some other warnings from these test classes.