### PR TITLE
Don't warn about missing tests with Android projects

### DIFF
--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -8,7 +8,7 @@
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>grader</artifactId>
   <name>grader</name>
-  <version>2021.3.0</version>
+  <version>2021.4.1</version>
   <packaging>jar</packaging>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -523,7 +523,7 @@ public class Submit extends EmailSender {
     }
   }
 
-  private void warnIfTestClassesAreNotSubmitted(Set<File> sourceFiles) {
+  protected void warnIfTestClassesAreNotSubmitted(Set<File> sourceFiles) {
     boolean wereTestClassessSubmitted = submittedTestClasses(sourceFiles);
     if (!wereTestClassessSubmitted && !this.isSubmittingKoans) {
       out.println("*** WARNING: You are not submitting a \"test\" directory.\n" +

--- a/grader/src/main/java/edu/pdx/cs410J/grader/SubmitAndroidProject.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/SubmitAndroidProject.java
@@ -22,6 +22,11 @@ public class SubmitAndroidProject extends Submit {
   }
 
   @Override
+  protected void warnIfTestClassesAreNotSubmitted(Set<File> sourceFiles) {
+
+  }
+
+  @Override
   protected String getZipEntryNameFor(File file) {
     return AndroidZipFixer.getFixedEntryName(file.getAbsolutePath());
   }


### PR DESCRIPTION
Address issue #295 by not issuing a warning when no test classes are submitted.