### PR TITLE
Issue 345 escape spaces in local repository path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,20 @@
             </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>replace-spaces-in-local-repository</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>localRepositoryWithEscapedSpaces</name>
+              <value>${settings.localRepository}</value>
+              <regex>\s</regex>
+              <replacement>%20</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -131,7 +131,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>${package}.Project5</mainClass>
             </manifest>
           </archive>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -131,7 +131,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>${package}.Project4</mainClass>
             </manifest>
           </archive>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -132,7 +132,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>${package}.Project4</mainClass>
             </manifest>
           </archive>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -133,7 +133,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>edu.pdx.cs410J.airlineweb.Project5</mainClass>
             </manifest>
           </archive>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -131,7 +131,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>edu.pdx.cs410J.apptbookweb.Project4</mainClass>
             </manifest>
           </archive>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -132,7 +132,7 @@
             <manifest>
               <addClasspath>true</addClasspath>
               <classpathLayoutType>repository</classpathLayoutType>
-              <classpathPrefix>file:///${user.home}/.m2/repository</classpathPrefix>
+              <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
               <mainClass>edu.pdx.cs410J.phonebillweb.Project4</mainClass>
             </manifest>
           </archive>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -93,7 +93,7 @@
             <archive>
               <manifest>
                 <addClasspath>true</addClasspath>
-                <classpathPrefix>${user.home}/.m2/repository/</classpathPrefix>
+                <classpathPrefix>file:///${localRepositoryWithEscapedSpaces}</classpathPrefix>
                 <classpathLayoutType>repository</classpathLayoutType>
                 <mainClass>edu.pdx.cs410J.di.RestfulCreditCardService</mainClass>
               </manifest>


### PR DESCRIPTION
Address issue #345 by replacing whitespace in the path to the local Maven repository (for instance, if the user's home directory has a space in it) with %20 so that it can be part of a valid file:// URL.