### PR TITLE
Issue 342 copy args in invoke main

### DIFF
--- a/examples/src/main/java/edu/pdx/cs410J/xml/BuildPhonebook.java
+++ b/examples/src/main/java/edu/pdx/cs410J/xml/BuildPhonebook.java
@@ -17,7 +17,7 @@ import java.net.MalformedURLException;
  * writes it to a file.
  */
 public class BuildPhonebook {
-  private static PrintStream err = System.err;
+  private static final PrintStream err = System.err;
 
   public static void main(String[] args) {
     Document doc = null;

--- a/projects-parent/projects/src/it/java/edu/pdx/cs410J/InvokeMainIT.java
+++ b/projects-parent/projects/src/it/java/edu/pdx/cs410J/InvokeMainIT.java
@@ -2,8 +2,7 @@ package edu.pdx.cs410J;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,38 +16,38 @@ public class InvokeMainIT extends InvokeMainTestCase {
   @Test
     public void testNoExitCode() {
         MainMethodResult result = invokeMain( NoExitCode.class );
-        assertNull( result.getExitCode() );
+        assertThat(result.getExitCode(), nullValue());
     }
 
     @Test
     public void testZeroExitCode() {
         MainMethodResult result = invokeMain( ZeroExitCode.class );
-        assertEquals(new Integer(0), result.getExitCode());
+        assertThat(result.getExitCode(), equalTo(0));
     }
 
     @Test
     public void testExitCodeOf1() {
         MainMethodResult result = invokeMain( ExitCodeOf1.class );
-        assertEquals(new Integer(1), result.getExitCode());
+        assertThat(result.getExitCode(), equalTo(1));
     }
 
     @Test
     public void testCommandLineArguments() {
         Integer exitCode = 27;
         MainMethodResult result = invokeMain( ExitCodeFromCommandLine.class, String.valueOf(exitCode) );
-        assertEquals( exitCode, result.getExitCode() );
+        assertThat(result.getExitCode(), equalTo(exitCode));
     }
 
     @Test
     public void testStandardOutput() {
         MainMethodResult result = invokeMain( WriteArgsToStandardOut.class, "1", "2", "3", "4", "5" );
-        assertEquals( "12345", result.getTextWrittenToStandardOut() );
+        assertThat(result.getTextWrittenToStandardOut(), equalTo("12345"));
     }
 
     @Test
     public void testStandardError() {
         MainMethodResult result = invokeMain( WriteArgsToStandardErr.class, "1", "2", "3", "4", "5" );
-        assertEquals( "12345", result.getTextWrittenToStandardError() );
+        assertThat(result.getTextWrittenToStandardError(), equalTo("12345"));
     }
 
   @Test
@@ -60,15 +59,17 @@ public class InvokeMainIT extends InvokeMainTestCase {
 
   @Test
   public void uncaughtExceptionInMainThrowsUncaughtExceptionInMain() {
-      try {
-        invokeMain(MainThrowsIllegalStateException.class);
-        fail("Should have thrown an UncaughtExceptionInMain");
+    UncaughtExceptionInMain ex = assertThrows(UncaughtExceptionInMain.class, () -> invokeMain(MainThrowsIllegalStateException.class));
 
-      } catch (UncaughtExceptionInMain ex) {
-        Throwable cause = ex.getCause();
-        assertThat(cause, instanceOf(IllegalStateException.class));
-        assertThat(cause.getMessage(), equalTo(UNCAUGHT_EXCEPTION_MESSAGE));
-      }
+    Throwable cause = ex.getCause();
+    assertThat(cause, instanceOf(IllegalStateException.class));
+    assertThat(cause.getMessage(), equalTo(UNCAUGHT_EXCEPTION_MESSAGE));
+  }
+
+  @Test
+  void canNotRelyOnEqualsOperatorToCompareArgs() {
+    MainMethodResult result = invokeMain(MainComparesArgStringWithEqualsOperator.class, (String) MainComparesArgStringWithEqualsOperator.ARG_STRING);
+    assertThat(result.getExitCode(), equalTo(0));
   }
 
     private static class NoExitCode
@@ -138,5 +139,19 @@ public class InvokeMainIT extends InvokeMainTestCase {
       throw new IllegalStateException(UNCAUGHT_EXCEPTION_MESSAGE);
     }
 
+  }
+
+  private static class MainComparesArgStringWithEqualsOperator {
+
+    private static final Object ARG_STRING = "ARG";
+
+    public static void main(String[] args) {
+      if (ARG_STRING == args[0]) {
+        System.exit(1);
+
+      } else if (ARG_STRING.equals(args[0])) {
+        System.exit(0);
+      }
+    }
   }
 }

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
@@ -67,7 +67,6 @@ public abstract class InvokeMainTestCase
         /**
          * Invokes the main method
          * @return This <code>MainMethodResult</code>
-         * @param b
          */
         public MainMethodResult invoke(boolean allowMutableStaticFields)
         {

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/InvokeMainTestCase.java
@@ -91,7 +91,7 @@ public abstract class InvokeMainTestCase
                 System.setErr( new PrintStream(newErr) );
 
                 try {
-                    main.invoke( null, (Object) this.args );
+                    main.invoke( null, (Object) copyOfArgs());
 
                 } catch ( InvocationTargetException ex ) {
                     if ( ex.getCause() instanceof ExitException ) {
@@ -110,6 +110,17 @@ public abstract class InvokeMainTestCase
                 System.setOut( oldOut );
                 System.setErr( oldErr );
             }
+        }
+
+        @SuppressWarnings("StringOperationCanBeSimplified")
+        private String[] copyOfArgs() {
+            String[] copy = new String[this.args.length];
+            String[] strings = this.args;
+            for (int i = 0; i < strings.length; i++) {
+                String arg = strings[i];
+                copy[i] = new String(arg);
+            }
+            return copy;
         }
 
         /**

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
@@ -1,0 +1,33 @@
+package edu.pdx.cs410J;
+
+import java.util.List;
+
+/**
+ * Throws when the <code>main</code> method of a class with mutable <code>static</code>
+ * fields is invoked with {@link InvokeMainTestCase#invokeMain(Class, String...)}.
+ *
+ * Main classes with mutable static fields have proven to be problematic because the
+ * values of the mutable fields are not reset in between tests.  As a result, the values
+ * of these fields from previous tests might stick around.  This has proven to be very
+ * confusing.
+ *
+ * @see InvokeMainTestCase#invokeMainAllowingMutableStaticFields(Class, String...)
+ */
+public class MainClassContainsMutableStaticFields extends RuntimeException {
+
+  private final Iterable<String> fieldNames;
+
+  public MainClassContainsMutableStaticFields(String className, List<String> fieldNames) {
+    super(getMessage(className, fieldNames));
+    this.fieldNames = fieldNames;
+  }
+
+  private static String getMessage(String className, List<String> fieldNames) {
+    String message = "Main class %s contains %d non-final static fields.  You probably don't want to store data in mutable static fields.  It might cause confusing behavior with your integration tests.";
+    return String.format(message, className, fieldNames.size());
+  }
+
+  public Iterable<String> getNamesOfMutableStaticFields() {
+    return this.fieldNames;
+  }
+}

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
@@ -1,6 +1,7 @@
 package edu.pdx.cs410J;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Throws when the <code>main</code> method of a class with mutable <code>static</code>
@@ -23,8 +24,14 @@ public class MainClassContainsMutableStaticFields extends RuntimeException {
   }
 
   private static String getMessage(String className, List<String> fieldNames) {
-    String message = "Main class %s contains %d non-final static fields.  You probably don't want to store data in mutable static fields.  It might cause confusing behavior with your integration tests.";
-    return String.format(message, className, fieldNames.size());
+    return "Main class \"" +
+      className +
+      "\" contains " +
+      fieldNames.size() +
+      " non-final static fields: " +
+      String.join(", ", fieldNames) +
+      ".  You probably don't want to store data in mutable static fields.  " +
+      "It might cause confusing behavior with your integration tests.";
   }
 
   public Iterable<String> getNamesOfMutableStaticFields() {

--- a/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
+++ b/projects-parent/projects/src/test/java/edu/pdx/cs410J/MainClassContainsMutableStaticFields.java
@@ -1,7 +1,6 @@
 package edu.pdx.cs410J;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Throws when the <code>main</code> method of a class with mutable <code>static</code>


### PR DESCRIPTION
Address #342 by making a copy of the argument class to the main method in InvokeMainTestCase so that the main method can't inadvertently rely on the == operator to compare strings from the command line.