### PR TITLE
Remove nickname from zip file attached to project submission

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Submit.java
@@ -233,7 +233,7 @@ public class Submit extends EmailSender {
   @VisibleForTesting
   void setStudent(Student student) {
     this.userId = student.getId();
-    this.userName = student.getFullName();
+    this.userName = student.getFirstName() + " " + student.getLastName();
     this.userEmail = student.getEmail();
   }
 
@@ -713,13 +713,18 @@ public class Submit extends EmailSender {
     DataHandler dh = new DataHandler(ds);
     MimeBodyPart filePart = new MimeBodyPart();
 
-    String zipFileTitle = userName.replace(' ', '_') + ".zip";
+    String zipFileTitle = getZipFileTitle();
 
     filePart.setDataHandler(dh);
     filePart.setFileName(zipFileTitle);
     filePart.setDescription(userName + "'s " + projName);
 
     return filePart;
+  }
+
+  @VisibleForTesting
+  String getZipFileTitle() {
+    return userName.replace(' ', '_') + ".zip";
   }
 
   private MimeBodyPart createTextPartOfTAEmail(Set<File> sourceFiles) throws MessagingException {

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SubmitTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -314,6 +316,27 @@ public class SubmitTest {
         submit.validateProjectName();
       }
     );
+  }
+
+  @Test
+  void zipFileAttachmentDoesNotContainStudentNickName() {
+    Student student = new Student("studentId");
+    String firstName = "FirstName";
+    String nickName = "NickName";
+    String lastName = "LastName";
+
+    student.setFirstName(firstName);
+    student.setNickName(nickName);
+    student.setLastName(lastName);
+
+    Submit submit = new Submit();
+    submit.setStudent(student);
+
+    String zipFileTitle = submit.getZipFileTitle();
+
+    assertThat(zipFileTitle, containsString(firstName));
+    assertThat(zipFileTitle, containsString(lastName));
+    assertThat(zipFileTitle, not(containsString(nickName)));
   }
 
 }


### PR DESCRIPTION
Resolve #381 by removing the nickname from the name of the zip file attached to the project submission email.