### PR TITLE
Use scm-publish-plugin to publish to GitHub pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,17 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-publish-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <scmBranch>gh-pages</scmBranch>
+            <addUniqueDirectory>true</addUniqueDirectory>
+            <skipDeletedFiles>true</skipDeletedFiles>  <!-- Attempting to delete file fails because there are too many files -->
+            <extraNormalizeExtensions>svg,rss</extraNormalizeExtensions>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -685,7 +696,7 @@
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>
-      <url>git:ssh://git@github.com/DavidWhitlock/PortlandStateJava.git?gh-pages#</url>
+      <url>scm:git:git@github.com:DavidWhitlock/PortlandStateJava.git</url>
     </site>
   </distributionManagement>
 </project>


### PR DESCRIPTION
Resolve #406 by configuring the scm-publish-plugin to publish the Maven site to GitHub pages.