### PR TITLE
Remove use of cargo plugin

### DIFF
--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,57 +60,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -59,59 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>
-                ${project.build.directory}/${project.build.finalName}.${project.packaging}
-              </location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -60,57 +60,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopPort>9999</stopPort>
           <stopKey>stop-jetty</stopKey>
           <webApp>
@@ -54,8 +53,6 @@
               <goal>start</goal>
             </goals>
             <configuration>
-              <scanIntervalSeconds>0</scanIntervalSeconds>
-              <daemon>true</daemon>
               <httpConnector>
                 <port>${jetty.http.port}</port>
               </httpConnector>


### PR DESCRIPTION
Remove use of the Maven cargo plugin because on the CI server it is bringing in a super-old version of Jetty that doesn't know to deal with a JDK version like "18.0.2.1".