### PR TITLE
Changes for Winter 2023

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '18' ]
+        java: [ '11', '17', '19' ]
     name: JDK ${{ matrix.Java }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17.0.4', '18.0.2' ]
+        java: [ '11.0.16', '17.0.4', '18.0.2' ]
     name: JDK ${{ matrix.Java }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11.0.16', '17.0.4', '18.0.2' ]
+        java: [ '11', '17', '18' ]
     name: JDK ${{ matrix.Java }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '17', '18' ]
+        java: [ '11', '17.0.4', '18.0.2' ]
     name: JDK ${{ matrix.Java }}
     steps:
     - uses: actions/checkout@v3

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,14 +6,10 @@
     <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>examples</artifactId>
   <name>examples</name>
   <version>2023.0.0-SNAPSHOT</version>
-  <url>http://www.cs.pdx.edu/~whitlock</url>
-  <properties>
-    <groovy.version>3.0.8</groovy.version>
-  </properties>
+  <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
@@ -36,20 +32,14 @@
       <version>${guice.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>${groovy.version}</version>
-      <type>pom</type>
-    </dependency>
-    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,23 +3,23 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>examples</artifactId>
   <name>examples</name>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>family</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>examples</artifactId>
   <name>examples</name>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <groovy.version>3.0.8</groovy.version>
@@ -18,12 +18,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>family</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiMainTest.java
@@ -21,7 +21,7 @@ public class MovieDatabaseRmiMainTest extends MovieDatabaseRmiTestCase {
     String title = "Black Panther";
     int year = 2018;
 
-    MainMethodResult result = invokeMain(CreateMovie.class, RMI_HOST, String.valueOf(RMI_PORT), title, String.valueOf(year));
+    MainMethodResult result = invokeMain(CreateMovie.class, RMI_HOST, String.valueOf(rmiPort), title, String.valueOf(year));
     assertThat(result.getTextWrittenToStandardOut(), containsString("Created movie"));
     assertThat(result.getTextWrittenToStandardError(), equalTo(""));
 

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
@@ -13,7 +13,7 @@ import java.rmi.registry.Registry;
 import java.rmi.server.UnicastRemoteObject;
 
 public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
-  static final int RMI_PORT = getRandomPort();
+  static int rmiPort;
 
   private static int getRandomPort() {
     return (int) (1_000 + Math.random() * (9_000 - 1));
@@ -26,13 +26,14 @@ public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
   @BeforeAll
   public static void bindMovieDatabaseIntoRmiRegistry() throws RemoteException, AlreadyBoundException, MalformedURLException {
     movieDatabaseImpl = new MovieDatabaseImpl();
-    MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(movieDatabaseImpl, RMI_PORT);
-    rmiRegistry = LocateRegistry.createRegistry(RMI_PORT);
+    rmiPort = getRandomPort();
+    MovieDatabase database = (MovieDatabase) UnicastRemoteObject.exportObject(movieDatabaseImpl, rmiPort);
+    rmiRegistry = LocateRegistry.createRegistry(rmiPort);
     rmiRegistry.bind(MovieDatabase.RMI_OBJECT_NAME, database);
   }
 
   @AfterAll
-  public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, MalformedURLException, AlreadyBoundException, NotBoundException {
+  public static void unbindMovieDatabaseFromRmiRegistry() throws RemoteException, NotBoundException {
     Registry registry = rmiRegistry;
     UnicastRemoteObject.unexportObject(movieDatabaseImpl, true);
     registry.unbind(MovieDatabase.RMI_OBJECT_NAME);
@@ -41,7 +42,7 @@ public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
   }
 
   private static Registry getRmiRegistry() throws RemoteException {
-    return LocateRegistry.getRegistry(RMI_HOST, RMI_PORT);
+    return LocateRegistry.getRegistry(RMI_HOST, rmiPort);
   }
 
   static MovieDatabase getMovieDatabase() throws RemoteException, NotBoundException {

--- a/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
+++ b/examples/src/test/java/edu/pdx/cs410J/rmi/MovieDatabaseRmiTestCase.java
@@ -16,7 +16,7 @@ public class MovieDatabaseRmiTestCase extends InvokeMainTestCase {
   static int rmiPort;
 
   private static int getRandomPort() {
-    return (int) (1_000 + Math.random() * (9_000 - 1));
+    return (int) (1_025 + Math.random() * (9_000 - 1));
   }
 
   static final String RMI_HOST = "localhost";

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -15,12 +15,6 @@
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
       <version>2023.0.0-SNAPSHOT</version>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>family</artifactId>
   <packaging>jar</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>CS410J Family Tree Application</name>
   <description>An example Java application for CS410J: Advanced Java Programming</description>
   <url>https://www.cs.pdx.edu/~whitlock</url>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -1,18 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
     <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>family</artifactId>
   <packaging>jar</packaging>
   <version>2023.0.0-SNAPSHOT</version>
   <name>CS410J Family Tree Application</name>
   <description>An example Java application for CS410J: Advanced Java Programming</description>
-  <url>http://www.cs.pdx.edu/~whitlock</url>
+  <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>family</artifactId>
   <packaging>jar</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>CS410J Family Tree Application</name>
   <description>An example Java application for CS410J: Advanced Java Programming</description>
   <url>http://www.cs.pdx.edu/~whitlock</url>
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -28,11 +28,6 @@
       <version>5.5.2</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.3.0-alpha10</version>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -8,7 +8,7 @@
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>grader</artifactId>
   <name>grader</name>
-  <version>${student.version}</version>
+  <version>${grader.version}</version>
   <packaging>jar</packaging>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <dependencies>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -5,12 +5,11 @@
     <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>grader</artifactId>
   <name>grader</name>
   <version>${grader.version}</version>
   <packaging>jar</packaging>
-  <url>http://www.cs.pdx.edu/~whitlock</url>
+  <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -25,12 +24,12 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>5.5.2</version>
+      <version>5.7.1</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.0-alpha10</version>
+      <version>1.4.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>grader</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/grader/src/main/java/edu/pdx/cs410J/grader/ProjectTimeEstimatesSummary.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/ProjectTimeEstimatesSummary.java
@@ -14,51 +14,67 @@ import static edu.pdx.cs410J.grader.gradebook.Assignment.ProjectType.*;
 
 public class ProjectTimeEstimatesSummary {
   public TimeEstimatesSummaries getTimeEstimateSummaries(GradeBook book) {
+    return getTimeEstimateSummaries(Collections.singletonList(book));
+  }
+
+  public TimeEstimatesSummaries getTimeEstimateSummaries(List<GradeBook> books) {
     TimeEstimatesSummaries summaries = new TimeEstimatesSummaries();
 
-    book.assignmentsStream().forEach(assignment -> {
-      ProjectType projectType = assignment.getProjectType();
-      if (projectType != null) {
-        summaries.addSummariesFor(book, assignment);
-      }
+    Set<ProjectType> projectTypes = new HashSet<>();
+    for (GradeBook book : books) {
+      book.assignmentsStream()
+        .map(Assignment::getProjectType)
+        .filter(Objects::nonNull)
+        .forEach(projectTypes::add);
+    }
+
+    projectTypes.forEach(projectType -> {
+      summaries.addSummariesFor(books, projectType);
     });
 
     return summaries;
   }
 
   public static void main(String[] args) {
-    String gradeBookFileName = null;
+    List<String> gradeBookFileNames = new ArrayList<>();
 
-    for (String arg : args) {
-      if (gradeBookFileName == null) {
-        gradeBookFileName = arg;
-      }
-    }
+    Collections.addAll(gradeBookFileNames, args);
 
-    if (gradeBookFileName == null) {
+    if (gradeBookFileNames.isEmpty()) {
       usage("Missing grade book file name");
       return;
     }
 
-    File gradeBookFile = new File(gradeBookFileName);
-    if (!gradeBookFile.exists()) {
-      usage("Cannot find grade book file: " + gradeBookFile);
-      return;
-    }
+    List<GradeBook> gradeBooks = gradeBookFileNames.stream()
+      .map(ProjectTimeEstimatesSummary::getExistingFile)
+      .map(ProjectTimeEstimatesSummary::parseGradeBookFile)
+      .collect(Collectors.toList());
 
+    ProjectTimeEstimatesSummary summary = new ProjectTimeEstimatesSummary();
+    TimeEstimatesSummaries summaries = summary.getTimeEstimateSummaries(gradeBooks);
+
+    PrintWriter pw = new PrintWriter(System.out, true);
+    summaries.generateMarkdown(pw, List.of(APP_CLASSES, TEXT_FILE, PRETTY_PRINT, KOANS, XML, REST, ANDROID));
+    pw.flush();
+
+  }
+
+  private static GradeBook parseGradeBookFile(File file) {
     try {
-      GradeBook book = new XmlGradeBookParser(gradeBookFile).parse();
-
-      ProjectTimeEstimatesSummary summary = new ProjectTimeEstimatesSummary();
-      TimeEstimatesSummaries summaries = summary.getTimeEstimateSummaries(book);
-
-      PrintWriter pw = new PrintWriter(System.out, true);
-      summaries.generateMarkdown(pw, List.of(APP_CLASSES, TEXT_FILE, PRETTY_PRINT, REST, ANDROID));
-      pw.flush();
+      return new XmlGradeBookParser(file).parse();
 
     } catch (ParserException | IOException e) {
-      usage("While parsing " + gradeBookFile + ": " + e);
+      usage("While parsing " + file + ": " + e);
+      return null;
     }
+  }
+
+  private static File getExistingFile(String fileName) {
+    File gradeBookFile = new File(fileName);
+    if (!gradeBookFile.exists()) {
+      usage("Cannot find grade book file: " + gradeBookFile);
+    }
+    return gradeBookFile;
   }
 
   private static void usage(String message) {
@@ -78,10 +94,17 @@ public class ProjectTimeEstimatesSummary {
       return this.summaries.get(projectType);
     }
 
-    void addSummariesFor(GradeBook book, Assignment assignment) {
-      Collection<Double> estimates = getEstimates(book, assignment);
-      if (!estimates.isEmpty()) {
-        summaries.put(assignment.getProjectType(), new TimeEstimatesSummary(estimates));
+    void addSummariesFor(List<GradeBook> books, ProjectType projectType) {
+      Collection<Double> allEstimates = new ArrayList<>();
+      books.forEach(book -> {
+        book.assignmentsStream()
+          .filter(assignment -> assignment.getProjectType() == projectType)
+          .map(assignment -> getEstimates(book, assignment))
+          .forEach(allEstimates::addAll);
+      });
+
+      if (!allEstimates.isEmpty()) {
+          summaries.put(projectType, new TimeEstimatesSummary(allEstimates));
       }
     }
 
@@ -146,7 +169,7 @@ public class ProjectTimeEstimatesSummary {
     }
 
     private void formatRowOfDoubles(PrintWriter pw, List<ProjectType> projectTypes, String rowTitle, Function<TimeEstimatesSummary, Double> cellValue) {
-      formatRow(pw, projectTypes, rowTitle,projectType -> {
+      formatRow(pw, projectTypes, rowTitle, projectType -> {
         TimeEstimatesSummary summary = getTimeEstimateSummary(projectType);
         if (summary == null) {
           return "n/a";
@@ -169,14 +192,14 @@ public class ProjectTimeEstimatesSummary {
 
     private void countRow(PrintWriter pw, List<ProjectType> projectTypes) {
       formatRow(pw, projectTypes, "Count", projectType -> {
-          TimeEstimatesSummary summary = getTimeEstimateSummary(projectType);
-          if (summary == null) {
-            return "0";
+        TimeEstimatesSummary summary = getTimeEstimateSummary(projectType);
+        if (summary == null) {
+          return "0";
 
-          } else {
-            return String.valueOf(summary.getCount());
-          }
-        });
+        } else {
+          return String.valueOf(summary.getCount());
+        }
+      });
     }
 
     private void headerRows(PrintWriter pw, List<ProjectType> projectTypes) {
@@ -198,6 +221,9 @@ public class ProjectTimeEstimatesSummary {
 
         case XML:
           return "XML";
+
+        case KOANS:
+          return "Koans";
 
         case REST:
           return "REST";

--- a/grader/src/main/java/edu/pdx/cs410J/grader/Survey.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Survey.java
@@ -132,6 +132,9 @@ public class Survey extends EmailSender {
 
     } else if (isEmailAddress(id)) {
       printErrorMessageAndExit("** Your student id cannot be an email address");
+
+    } else if (!isJavaIdentifier(id)) {
+      printErrorMessageAndExit("** Your student id must be a valid Java identifier");
     }
 
     Student student = new Student(id);
@@ -156,6 +159,26 @@ public class Survey extends EmailSender {
     } catch (AddressException e) {
       return false;
     }
+  }
+
+  @VisibleForTesting
+  static boolean isJavaIdentifier(String id) {
+    if (id == null || id.equals("")) {
+      return false;
+    }
+
+    if (!Character.isJavaIdentifierStart(id.charAt(0))) {
+      return false;
+    }
+
+    for (int i = 1; i < id.length(); i++) {
+      char c = id.charAt(i);
+      if (!Character.isJavaIdentifierPart(c)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private void askEnrolledSectionQuestion(Student student) {

--- a/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/Assignment.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/Assignment.java
@@ -28,12 +28,13 @@ public class Assignment extends NotableImpl {
     APP_CLASSES,
     TEXT_FILE,
     PRETTY_PRINT,
+    KOANS,
     XML,
     REST,
     ANDROID
   }
 
-  private String name;
+  private final String name;
   private String description;
   private double points;
   private int canvasId;

--- a/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/GradeBook.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/GradeBook.java
@@ -97,14 +97,17 @@ public class GradeBook {
 
   /**
    * Adds an <code>Assignment</code> to this class
+   *
+   * @return <code>assignment</code> so that method calls can be chained
    */
-  public void addAssignment(Assignment assign) {
+  public Assignment addAssignment(Assignment assignment) {
     this.setDirty(true);
-    this.assignments.put(assign.getName(), assign);
+    this.assignments.put(assignment.getName(), assignment);
+    return assignment;
   }
 
   /**
-   * Returns the ids of all of the students in this class
+   * Returns the ids of all the students in this class
    */
   public Set<String> getStudentIds() {
     return this.students.keySet();
@@ -121,11 +124,13 @@ public class GradeBook {
   /**
    * Adds a <code>Student</code> to this <code>GradeBook</code>
    *
+   * @return <code>student</code> so that calls can be chained
    * @see #containsStudent
    */
-  public void addStudent(Student student) {
+  public Student addStudent(Student student) {
     this.setDirty(true);
     this.students.put(student.getId(), student);
+    return student;
   }
 
   /**

--- a/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/Student.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/Student.java
@@ -517,9 +517,9 @@ public class Student extends NotableImpl {
     this.addLate(assignment.getName());
   }
 
-  public void setGrade(Assignment assignment, double score) {
+  public Student setGrade(Assignment assignment, double score) {
     this.setGrade(assignment, new Grade(assignment, score));
-
+    return this;
   }
 
   public Student setEnrolledSection(Section enrolledSection) {

--- a/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/XmlDumper.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/XmlDumper.java
@@ -268,6 +268,10 @@ public class XmlDumper extends XmlHelper {
           assignmentNode.setAttribute("project-type", "PRETTY_PRINT");
           break;
 
+        case KOANS:
+          assignmentNode.setAttribute("project-type", "KOANS");
+          break;
+
         case XML:
           assignmentNode.setAttribute("project-type", "XML");
           break;

--- a/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/XmlGradeBookParser.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/gradebook/XmlGradeBookParser.java
@@ -184,6 +184,10 @@ public class XmlGradeBookParser extends XmlHelper {
           assignment.setProjectType(PRETTY_PRINT);
           break;
 
+        case "KOANS":
+          assignment.setProjectType(KOANS);
+          break;
+
         case "XML":
           assignment.setProjectType(XML);
           break;

--- a/grader/src/main/resources/edu/pdx/cs410J/grader/gradebook.dtd
+++ b/grader/src/main/resources/edu/pdx/cs410J/grader/gradebook.dtd
@@ -48,7 +48,7 @@ points it is worth, a type, a due date, and some optional notes -->
 <!ELEMENT assignment (name, description?, points, canvas-id?, due-date?, notes*)>
 <!ATTLIST assignment
   type         (PROJECT | QUIZ | OTHER | POA | OPTIONAL)  #REQUIRED
-  project-type (APP_CLASSES | TEXT_FILE | PRETTY_PRINT | XML | REST | ANDROID)  #IMPLIED
+  project-type (APP_CLASSES | TEXT_FILE | PRETTY_PRINT | KOANS | XML | REST | ANDROID)  #IMPLIED
 >
 
 <!ELEMENT description (#PCDATA)>

--- a/grader/src/test/java/edu/pdx/cs410J/grader/ProjectTimeEstimatesSummaryTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/ProjectTimeEstimatesSummaryTest.java
@@ -347,4 +347,25 @@ public class ProjectTimeEstimatesSummaryTest {
     TimeEstimatesSummaries summaries = summary.getTimeEstimateSummaries(book);
     assertThat(summaries.getTimeEstimateSummary(APP_CLASSES), nullValue());
   }
+
+  @Test
+  void calculationsUsingMultipleGradeBooks() {
+    GradeBook book1 = new GradeBook("Book 1");
+    GradeBook book2 = new GradeBook("Book 2");
+
+    ProjectType projectType = APP_CLASSES;
+
+    Assignment project1 = addProject(book1, projectType);
+    noteSubmission(addStudent(book1, "student1"), project1, 1.0);
+    noteSubmission(addStudent(book1, "student2"), project1, 2.0);
+    Assignment project2 = addProject(book2, projectType);
+    noteSubmission(addStudent(book2, "student4"), project2, 4.0);
+    noteSubmission(addStudent(book2, "student5"), project2, 5.0);
+
+    ProjectTimeEstimatesSummary summary = new ProjectTimeEstimatesSummary();
+    TimeEstimatesSummaries summaries = summary.getTimeEstimateSummaries(List.of(book1, book2));
+    TimeEstimatesSummary estimates = summaries.getTimeEstimateSummary(projectType);
+    assertThat(estimates.getCount(), equalTo(4));
+    assertThat(estimates.getAverage(), equalTo(3.0));
+  }
 }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SummaryReportTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SummaryReportTest.java
@@ -2,16 +2,10 @@ package edu.pdx.cs410J.grader;
 
 import com.google.common.io.CharStreams;
 import edu.pdx.cs410J.grader.gradebook.*;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.*;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -24,40 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class SummaryReportTest {
-
-  private File tempDirectory;
-
-  @BeforeEach
-  public void createTempDirectoryForTest() {
-    String tempDirName = "SummaryReportTestTempDirectory-" + System.currentTimeMillis();
-    tempDirectory = new File(System.getProperty("java.io.tmpdir"), tempDirName);
-    System.out.println("Temp dir is " + tempDirectory.getAbsolutePath());
-
-    boolean dirWasCreated = tempDirectory.mkdirs();
-    assertThat(dirWasCreated, equalTo(true));
-  }
-
-  @AfterEach
-  public void deleteTempDirectoryForTest() throws IOException {
-    Files.walkFileTree(tempDirectory.toPath(), new SimpleFileVisitor<Path>() {
-      @Override
-      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        return deleteFile(file);
-      }
-
-      @Override
-      public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-        return deleteFile(dir);
-      }
-
-      private FileVisitResult deleteFile(Path file) throws IOException {
-        Files.delete(file);
-        return FileVisitResult.CONTINUE;
-      }
-    });
-
-    assertThat(tempDirectory.exists(), equalTo(false));
-  }
 
   @Test
   public void ungradedAssignmentsDoNotCountTowardsGraded() {
@@ -75,7 +35,7 @@ public class SummaryReportTest {
   }
 
   @Test
-  public void reportsAreGeneratedInCorrectDirectories() throws IOException {
+  public void reportsAreGeneratedInCorrectDirectories(@TempDir File tempDirectory) throws IOException {
     GradeBook gradeBook = new GradeBook("test");
     Assignment assignment = new Assignment("assignment", 4.0);
     gradeBook.addAssignment(assignment);
@@ -88,8 +48,8 @@ public class SummaryReportTest {
 
     SummaryReport.dumpReports(gradeBook.getStudentIds(), gradeBook, tempDirectory, false);
 
-    assertThatStudentHasReportInDirectoryWithScore(undergrad, UNDERGRADUATE_DIRECTORY_NAME, undergradScore);
-    assertThatStudentHasReportInDirectoryWithScore(grad, GRADUATE_DIRECTORY_NAME, gradScore);
+    assertThatStudentHasReportInDirectoryWithScore(undergrad, tempDirectory, UNDERGRADUATE_DIRECTORY_NAME, undergradScore);
+    assertThatStudentHasReportInDirectoryWithScore(grad, tempDirectory, GRADUATE_DIRECTORY_NAME, gradScore);
   }
 
   private Student addStudentInSectionWithScore(GradeBook gradeBook, Assignment assignment, String studentId, Student.Section enrolledSection, double undergradScore) {
@@ -100,7 +60,7 @@ public class SummaryReportTest {
     return undergrad;
   }
 
-  private void assertThatStudentHasReportInDirectoryWithScore(Student student, String dirFileName, double studentScore) throws IOException {
+  private void assertThatStudentHasReportInDirectoryWithScore(Student student, File tempDirectory, String dirFileName, double studentScore) throws IOException {
     File directory = new File(tempDirectory, dirFileName);
     assertThat(directory.exists(), equalTo(true));
 
@@ -148,27 +108,25 @@ public class SummaryReportTest {
   private void calculateTotalGradesForStudents(GradeBook gradeBook, boolean assignLetterGrades) {
     PrintWriter pw = new PrintWriter(new Writer() {
       @Override
-      public void write(char[] cbuf, int off, int len) throws IOException {
+      public void write(char[] cbuf, int off, int len) {
 
       }
 
       @Override
-      public void flush() throws IOException {
+      public void flush() {
 
       }
 
       @Override
-      public void close() throws IOException {
+      public void close() {
 
       }
     });
 
-    gradeBook.studentsStream().forEach(student -> {
-      SummaryReport.dumpReportTo(gradeBook, student, pw, assignLetterGrades);
-    });
+    gradeBook.studentsStream().forEach(student -> SummaryReport.dumpReportTo(gradeBook, student, pw, assignLetterGrades));
   }
 
-  private class CapturingPrintWriter extends PrintWriter {
+  private static class CapturingPrintWriter extends PrintWriter {
     public CapturingPrintWriter() {
       super(new StringWriter());
     }
@@ -229,6 +187,66 @@ public class SummaryReportTest {
     assignment.setDueDate(dueDate);
 
     assertThat(SummaryReport.dueDateHasPassed(assignment), equalTo(false));
+  }
+
+  @Test
+  void assignmentWithAllZeroGradesDoesNotAppearInReport(@TempDir File tempDirectory) throws IOException {
+    GradeBook gradeBook = new GradeBook("test");
+    String someNonZeroGradesName = "someNonZeroGrades";
+    String allZeroGradesName = "allZeroGrades";
+
+    Assignment someNonZeroGrades = gradeBook.addAssignment(new Assignment(someNonZeroGradesName, 10.0));
+    Assignment allZeroGrades = gradeBook.addAssignment(new Assignment(allZeroGradesName, 10.0));
+
+    Student studentWithSomeNonZeroGrades =
+      gradeBook.addStudent(new Student("studentWithSomeNonZeroGrades"))
+        .setLastName("studentWithSomeNonZeroGrades")
+        .setEnrolledSection(UNDERGRADUATE)
+        .setGrade(someNonZeroGrades, 5.0)
+        .setGrade(allZeroGrades, 0.0);
+
+    Student studentWithAllZeroGrades =
+      gradeBook.addStudent(new Student("studentWithAllZeroGrades"))
+        .setLastName("studentWithAllZeroGrades")
+        .setEnrolledSection(UNDERGRADUATE)
+        .setGrade(someNonZeroGrades, 0.0)
+        .setGrade(allZeroGrades, 0.0);
+
+    assertThat(SummaryReport.noStudentHasGradeFor(allZeroGrades, gradeBook), equalTo(true));
+
+    SummaryReport.dumpReports(gradeBook.getStudentIds(), gradeBook, tempDirectory, false);
+
+    File studentWithSomeNonZeroGradesReportFile = getStudentReportFile(tempDirectory, studentWithSomeNonZeroGrades);
+    assertThat(studentWithSomeNonZeroGradesReportFile.exists(), equalTo(true));
+
+    String studentWithSomeNonZeroGradesReport = readTextFromFile(studentWithSomeNonZeroGradesReportFile);
+    assertThat(studentWithSomeNonZeroGradesReport, containsString(someNonZeroGradesName));
+    assertThat(studentWithSomeNonZeroGradesReport, not(containsString(allZeroGradesName)));
+
+    File studentWithAllZeroGradesReportFile = getStudentReportFile(tempDirectory, studentWithAllZeroGrades);
+    assertThat(studentWithAllZeroGradesReportFile.exists(), equalTo(true));
+
+    String studentWithAllZeroGradesReport = readTextFromFile(studentWithAllZeroGradesReportFile);
+    assertThat(studentWithAllZeroGradesReport, containsString(someNonZeroGradesName));
+    assertThat(studentWithAllZeroGradesReport, not(containsString(allZeroGradesName)));
+
+  }
+
+  private static File getStudentReportFile(File directory, Student student) {
+    String sectionDirName;
+    switch (student.getEnrolledSection()) {
+      case GRADUATE:
+        sectionDirName = GRADUATE_DIRECTORY_NAME;
+        break;
+      case UNDERGRADUATE:
+        sectionDirName = UNDERGRADUATE_DIRECTORY_NAME;
+        break;
+      default:
+        throw new UnsupportedOperationException("Don't know how to handle section: " + student.getEnrolledSection());
+    }
+
+    File sectionDirectory = new File(directory, sectionDirName);
+    return new File(sectionDirectory, SummaryReport.getReportFileName(student.getId()));
   }
 
 }

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SurveyTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SurveyTest.java
@@ -68,6 +68,18 @@ public class SurveyTest {
   }
 
   @Test
+  void invalidJavaIdentifierIsInvalid() {
+    String id = "123";
+    assertThat(Survey.isJavaIdentifier(id), equalTo(false));
+  }
+
+  @Test
+  void validJavaIdentifierIsValid() {
+    String id = "whitlock123";
+    assertThat(Survey.isJavaIdentifier(id), equalTo(true));
+  }
+
+  @Test
   void successfulSurveyWritesStudentXmlFile(@TempDir File tempDir) throws IOException, ParserException {
     String firstName = "First name";
     String lastName = "Last name";

--- a/grader/src/test/java/edu/pdx/cs410J/grader/gradebook/GradeBookXmlTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/gradebook/GradeBookXmlTest.java
@@ -175,6 +175,11 @@ public class GradeBookXmlTest {
   }
 
   @Test
+  void koansProjectTypeIsPersistedToXml() throws ParserException, IOException, TransformerException {
+    persistProjectOfType(KOANS);
+  }
+
+  @Test
   void xmlProjectTypeIsPersistedToXml() throws ParserException, IOException, TransformerException {
     persistProjectOfType(XML);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
       <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
       <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-      <jetty-maven-plugin.version>9.4.46.v20220331</jetty-maven-plugin.version>
+      <jetty-maven-plugin.version>9.4.48.v20220622</jetty-maven-plugin.version>
       <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
       <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
       <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <jacoco.max.missed.classes>0</jacoco.max.missed.classes>
       <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
 
-      <student.version>2023.0.0-SNAPSHOT</student.version>
+      <grader.version>2023.0.0-SNAPSHOT</grader.version>
     </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
     </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
       <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
       <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-      <jetty-maven-plugin.version>9.4.48.v20220622</jetty-maven-plugin.version>
+      <jetty-maven-plugin.version>10.0.11</jetty-maven-plugin.version>
       <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
       <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
       <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <artifactId>cs410j</artifactId>
   <packaging>pom</packaging>
   <name>CS410J Java Example Code</name>
@@ -90,7 +90,7 @@
       <jacoco.max.missed.classes>0</jacoco.max.missed.classes>
       <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
 
-      <student.version>2022.5.0</student.version>
+      <student.version>2023.0.0-SNAPSHOT</student.version>
     </properties>
     <repositories>
       <repository>  <!-- Needed for Groovy dependencies -->
@@ -689,6 +689,10 @@
       <id>ossrh</id>
       <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
     <site>
       <id>gh-pages</id>
       <name>GitHub Pages</name>

--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,6 @@
 
       <student.version>2023.0.0-SNAPSHOT</student.version>
     </properties>
-    <repositories>
-      <repository>  <!-- Needed for Groovy dependencies -->
-        <id>jcenter</id>
-        <name>bintray</name>
-        <url>https://jcenter.bintray.com</url>
-      </repository>
-    </repositories>
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,33 +62,35 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <pmd.version>6.45.0</pmd.version>
+        <pmd.version>6.52.0</pmd.version>
 
         <wagon-git.version>2.0.3</wagon-git.version> <!-- Do not upgrade to 2.0.4 as it doesn't work -->
-        <wagon-ssh.version>3.4.3</wagon-ssh.version>
+        <wagon-ssh.version>3.5.2</wagon-ssh.version>
 
-        <junit.version>5.9.0-M1</junit.version>
+        <junit.version>5.9.1</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <mockito.version>4.5.1</mockito.version>
-        <surefire.version>3.0.0-M6</surefire.version>
-      <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
+        <mockito.version>4.9.0</mockito.version>
+        <surefire.version>3.0.0-M7</surefire.version>
+      <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
       <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
       <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-      <jetty-maven-plugin.version>10.0.11</jetty-maven-plugin.version>
-      <spotbugs-maven-plugin.version>4.7.0.0</spotbugs-maven-plugin.version>
+      <jetty-maven-plugin.version>10.0.12</jetty-maven-plugin.version>
+      <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
       <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
-      <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+      <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
       <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-      <maven-project-info-reports-plugin.version>3.3.0</maven-project-info-reports-plugin.version>
-      <maven-surefire-report-plugin.version>3.0.0-M6</maven-surefire-report-plugin.version>
-      <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-      <checkstyle.version>10.2</checkstyle.version>
+      <maven-project-info-reports-plugin.version>3.4.1</maven-project-info-reports-plugin.version>
+      <maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
+      <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+      <checkstyle.version>10.5.0</checkstyle.version>
       <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
-      <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
+      <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
+      <maven-pmd-plugin.version>3.19.0</maven-pmd-plugin.version>
+      <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
+      <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
 
       <jacoco.min.instruction.covered.ratio>0.75</jacoco.min.instruction.covered.ratio>
       <jacoco.max.missed.classes>0</jacoco.max.missed.classes>
-      <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
 
       <grader.version>2023.0.0-SNAPSHOT</grader.version>
     </properties>
@@ -122,7 +124,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>enforce-versions</id>
@@ -192,12 +194,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -473,17 +475,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M7</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -551,7 +553,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M1</version>
+          <version>4.0.0-M4</version>
           <dependencies>
             <dependency>
               <groupId>net.trajano.wagon</groupId>
@@ -568,7 +570,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>${maven-checkstyle-plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -587,6 +589,11 @@
             <skipDeletedFiles>true</skipDeletedFiles>  <!-- Attempting to delete file fails because there are too many files -->
             <extraNormalizeExtensions>svg,rss</extraNormalizeExtensions>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${versions-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -611,7 +618,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <configuration>
           <linkJavadoc>true</linkJavadoc>
         </configuration>
@@ -619,7 +626,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.11.0</version>
+        <version>${versions-maven-plugin.version}</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <artifactId>cs410j</artifactId>
   <packaging>pom</packaging>
   <name>CS410J Java Example Code</name>
@@ -92,7 +92,7 @@
       <jacoco.min.instruction.covered.ratio>0.75</jacoco.min.instruction.covered.ratio>
       <jacoco.max.missed.classes>0</jacoco.max.missed.classes>
 
-      <grader.version>2023.0.0-SNAPSHOT</grader.version>
+      <grader.version>2023.0.0</grader.version>
     </properties>
   <dependencies>
     <dependency>

--- a/projects-parent/archetypes-parent/airline-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>airline-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-archetype</name>

--- a/projects-parent/archetypes-parent/airline-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-archetype</name>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -40,6 +40,12 @@
         <include>**/*.xml</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -146,7 +146,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,17 +30,6 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
       <version>2023.0.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements AirlineDumper<Airline> {
   private final Writer writer;
 

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements AirlineParser<Airline> {
   private final Reader reader;
 

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-web-archetype</name>

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-web-archetype</name>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -23,6 +23,12 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -137,7 +137,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/AirlineRestClientIT.java
@@ -62,5 +62,5 @@ class AirlineRestClientIT {
     HttpRequestHelper.RestException ex =
       assertThrows(HttpRequestHelper.RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(AirlineServlet.WORD_PARAMETER)));
   }}

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/Project5IT.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/it/java/Project5IT.java
@@ -42,6 +42,9 @@ class Project5IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project5.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -65,14 +68,23 @@ class Project5IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project5.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project5.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project5.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
@@ -48,6 +48,7 @@ public class AirlineRestClient
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -57,7 +58,7 @@ public class AirlineRestClient
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(AirlineServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -66,7 +67,7 @@ public class AirlineRestClient
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = http.post(Map.of("word", word, "definition", definition));
+    Response response = http.post(Map.of(AirlineServlet.WORD_PARAMETER, word, AirlineServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
@@ -21,7 +21,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/Project5.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/Project5.java
@@ -83,7 +83,7 @@ public class Project5 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineServletTest.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineServletTest.java
@@ -48,8 +48,8 @@ class AirlineServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(AirlineServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(AirlineServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-archetype</artifactId>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>apptbook-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -39,6 +39,12 @@
         <include>**/*.txt</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -146,7 +146,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,17 +30,6 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
       <version>2023.0.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
@@ -10,6 +10,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements AppointmentBookDumper<AppointmentBook> {
   private final Writer writer;
 

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
@@ -11,6 +11,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements AppointmentBookParser<AppointmentBook> {
   private final Reader reader;
 

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-web-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-web-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -23,6 +23,12 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -137,7 +137,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -62,6 +62,6 @@ class AppointmentBookRestClientIT {
     RestException ex =
       assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));  }
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(AppointmentBookServlet.WORD_PARAMETER)));  }
 
 }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -42,6 +42,9 @@ class Project4IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -65,14 +68,23 @@ class Project4IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
@@ -47,6 +47,7 @@ public class AppointmentBookRestClient {
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -56,7 +57,7 @@ public class AppointmentBookRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(AppointmentBookServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -65,7 +66,7 @@ public class AppointmentBookRestClient {
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL(Map.of("word", word, "definition", definition));
+    Response response = postToMyURL(Map.of(AppointmentBookServlet.WORD_PARAMETER, word, AppointmentBookServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
@@ -21,7 +21,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
@@ -83,7 +83,7 @@ public class Project4 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
@@ -49,8 +49,8 @@ public class AppointmentBookServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(AppointmentBookServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(AppointmentBookServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -8,7 +8,6 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>java-koans-archetype</artifactId>
   <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
@@ -48,7 +47,7 @@
     <developer>
       <id>dwhitlock</id>
       <name>David Whitlock</name>
-      <url>http://www.cs.pdx.edu/~whitlock</url>
+      <url>https://www.cs.pdx.edu/~whitlock</url>
       <roles>
         <role>Maven-izer</role>
       </roles>
@@ -57,9 +56,9 @@
       <id>YOU</id>
       <name>Your name here</name>
       <email>you@youremail.com</email>
-      <url>http://www.cs.pdx.edu/~YOU</url>
+      <url>https://www.cs.pdx.edu/~YOU</url>
       <organization>PSU Department of Computer Science</organization>
-      <organizationUrl>http://www.cs.pdx.edu</organizationUrl>
+      <organizationUrl>https://www.cs.pdx.edu</organizationUrl>
       <roles>
         <role>Student who does koans</role>
       </roles>

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>java-koans-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>java-koans-archetype</name>
@@ -66,4 +66,18 @@
       <timezone>-7</timezone>
     </developer>
   </developers>
+
+  <repositories>
+    <repository>
+      <id>maven-snapshots</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>java-koans-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>java-koans-archetype</name>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -107,6 +107,19 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>maven-snapshots</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
   <profiles>
     <profile>
       <id>grader</id>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -68,7 +68,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>${exec-maven-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -91,7 +91,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.0</version>
         <configuration>
           <filesets>
             <fileset>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.com.sandwich</groupId>
       <artifactId>koans-lib</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
   </dependencies>
   <properties>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.com.sandwich</groupId>
       <artifactId>koans-lib</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <properties>

--- a/projects-parent/archetypes-parent/kata-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kata-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>kata-archetype</name>

--- a/projects-parent/archetypes-parent/kata-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>kata-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>kata-archetype</name>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -111,7 +111,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/main/java/Kata.java
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/main/java/Kata.java
@@ -3,6 +3,8 @@
 #set( $symbol_escape = '\' )
 package ${package};
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * A class for getting started with a code kata
  *
@@ -11,6 +13,7 @@ package ${package};
  */
 public class Kata {
 
+  @VisibleForTesting
   public static void main(String[] args) {
     System.err.println("Missing command line arguments");
   }

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/kata-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/kata-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phonebill-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phonebill-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -39,6 +39,12 @@
         <include>**/*.txt</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -49,12 +49,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -147,7 +147,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,20 +30,9 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements PhoneBillDumper<PhoneBill> {
   private final Writer writer;
 

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
@@ -10,6 +10,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements PhoneBillParser<PhoneBill> {
   private final Reader reader;
 

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/test/java/TextDumperTest.java
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/src/test/java/TextDumperTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class TextDumperTest {
 
   @Test
-  void appointmentBookOwnerIsDumpedInTextFormat() {
+  void phoneBillOwnerIsDumpedInTextFormat() {
     String customer = "Test Phone Bill";
     PhoneBill bill = new PhoneBill(customer);
 

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-web-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-web-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -23,6 +23,12 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" encoding="UTF-8">
+      <directory>src/site</directory>
+      <includes>
+        <include>**/*.xml</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">
       <directory>src/it/java</directory>
       <includes>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -138,7 +138,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,57 +60,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
@@ -62,7 +62,7 @@ class PhoneBillRestClientIT {
     RestException ex =
       assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(PhoneBillServlet.WORD_PARAMETER)));
   }
 
 }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/Project4IT.java
@@ -41,6 +41,9 @@ class Project4IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -64,14 +67,23 @@ class Project4IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
@@ -48,6 +48,7 @@ public class PhoneBillRestClient {
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -57,7 +58,7 @@ public class PhoneBillRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(PhoneBillServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -66,7 +67,7 @@ public class PhoneBillRestClient {
   }
 
     public void addDictionaryEntry(String word, String definition) throws IOException {
-      Response response = http.post(Map.of("word", word, "definition", definition));
+      Response response = http.post(Map.of(PhoneBillServlet.WORD_PARAMETER, word, PhoneBillServlet.DEFINITION_PARAMETER, definition));
       throwExceptionIfNotOkayHttpStatus(response);
     }
 

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PrettyPrinter.java
@@ -21,7 +21,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
@@ -82,24 +82,11 @@ public class Project4 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 
         System.out.println(message);
-    }
-
-    /**
-     * Makes sure that the give response has the expected HTTP status code
-     * @param code The expected status code
-     * @param response The response from the server
-     */
-    private static void checkResponseCode( int code, HttpRequestHelper.Response response )
-    {
-        if (response.getHttpStatusCode() != code) {
-            error(String.format("Expected HTTP code %d, got code %d.${symbol_escape}n${symbol_escape}n%s", code,
-                                response.getHttpStatusCode(), response.getContent()));
-        }
     }
 
     private static void error( String message )

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,29 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillServletTest.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillServletTest.java
@@ -49,8 +49,8 @@ class PhoneBillServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(PhoneBillServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(PhoneBillServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/archetypes-parent/pom.xml
+++ b/projects-parent/archetypes-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2023.0.0-SNAPSHOT</version>
+        <version>2023.0.0</version>
     </parent>
 
     <artifactId>archetypes-parent</artifactId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/archetypes-parent/pom.xml
+++ b/projects-parent/archetypes-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2022.1.0</version>
+        <version>2023.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>archetypes-parent</artifactId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/archetypes-parent/student-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>student-archetype</artifactId>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Archetype for Student project</name>
@@ -51,5 +51,19 @@
       <timezone>-7</timezone>
     </developer>
   </developers>
+
+  <repositories>
+    <repository>
+      <id>maven-snapshots</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
 </project>

--- a/projects-parent/archetypes-parent/student-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
 
   <artifactId>student-archetype</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>maven-archetype</packaging>
 
   <name>Archetype for Student project</name>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/.mvn/wrapper/maven-wrapper.properties
@@ -1,5 +1,5 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -102,12 +102,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -102,12 +102,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -130,7 +130,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/site/site.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/site/verify.groovy
+++ b/projects-parent/archetypes-parent/student-archetype/src/test/resources/projects/site/verify.groovy
@@ -1,0 +1,17 @@
+def projectDir = new File(basedir, "project/site")
+def indexDotHtml = new File(projectDir, "target/site/index.html")
+if (!indexDotHtml.exists()) {
+  throw new FileNotFoundException("Couldn't find index.html " + indexDotHtml)
+}
+
+String html = indexDotHtml.text
+
+def expectedText = "Distribution Management"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}
+
+expectedText = "apache-maven-fluido"
+if (!html.contains(expectedText)) {
+  throw new IllegalStateException("Didn't fine expected text: " + expectedText)
+}

--- a/projects-parent/originals-parent/airline-web/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/airline-web/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -59,59 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>
-                ${project.build.directory}/${project.build.finalName}.${project.packaging}
-              </location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,24 +14,24 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>Airline Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -137,7 +137,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,24 +14,24 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>Airline Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/AirlineRestClientIT.java
@@ -59,5 +59,5 @@ class AirlineRestClientIT {
     HttpRequestHelper.RestException ex =
       assertThrows(HttpRequestHelper.RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(AirlineServlet.WORD_PARAMETER)));
   }}

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project5IT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs410J/airlineweb/Project5IT.java
@@ -39,6 +39,9 @@ class Project5IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project5.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -62,14 +65,23 @@ class Project5IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project5.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project5.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project5.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/AirlineRestClient.java
@@ -45,6 +45,7 @@ public class AirlineRestClient
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -54,7 +55,7 @@ public class AirlineRestClient
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(AirlineServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -63,7 +64,7 @@ public class AirlineRestClient
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = http.post(Map.of("word", word, "definition", definition));
+    Response response = http.post(Map.of(AirlineServlet.WORD_PARAMETER, word, AirlineServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/PrettyPrinter.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/PrettyPrinter.java
@@ -18,7 +18,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/Project5.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs410J/airlineweb/Project5.java
@@ -80,7 +80,7 @@ public class Project5 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 

--- a/projects-parent/originals-parent/airline-web/src/site/site.xml
+++ b/projects-parent/originals-parent/airline-web/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/AirlineServletTest.java
+++ b/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs410J/airlineweb/AirlineServletTest.java
@@ -45,8 +45,8 @@ class AirlineServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(AirlineServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(AirlineServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/originals-parent/airline/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/airline/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>airline</artifactId>
   <packaging>jar</packaging>
-  <version>2022.2.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>CS410J Airline Project</name>
   <description>An Airline application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>airline</artifactId>
   <packaging>jar</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>CS410J Airline Project</name>
   <description>An Airline application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -146,7 +146,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -30,17 +30,6 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
       <version>2023.0.0-SNAPSHOT</version>

--- a/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs410J/airline/TextDumper.java
+++ b/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs410J/airline/TextDumper.java
@@ -2,10 +2,12 @@ package edu.pdx.cs410J.airline;
 
 import edu.pdx.cs410J.AirlineDumper;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements AirlineDumper<Airline> {
   private final Writer writer;
 

--- a/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs410J/airline/TextParser.java
+++ b/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs410J/airline/TextParser.java
@@ -5,9 +5,11 @@ import edu.pdx.cs410J.ParserException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements AirlineParser<Airline> {
   private final Reader reader;
 

--- a/projects-parent/originals-parent/airline/src/site/site.xml
+++ b/projects-parent/originals-parent/airline/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/apptbook-web/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/apptbook-web/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,24 +14,24 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>Appointment Book Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -59,57 +59,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,24 +14,24 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>Appointment Book Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -137,7 +137,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClientIT.java
@@ -59,6 +59,6 @@ class AppointmentBookRestClientIT {
     RestException ex =
       assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));  }
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(AppointmentBookServlet.WORD_PARAMETER)));  }
 
 }

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs410J/apptbookweb/Project4IT.java
@@ -39,6 +39,9 @@ class Project4IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -62,14 +65,23 @@ class Project4IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/AppointmentBookRestClient.java
@@ -44,6 +44,7 @@ public class AppointmentBookRestClient {
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -53,7 +54,7 @@ public class AppointmentBookRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(AppointmentBookServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -62,7 +63,7 @@ public class AppointmentBookRestClient {
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    Response response = postToMyURL(Map.of("word", word, "definition", definition));
+    Response response = postToMyURL(Map.of(AppointmentBookServlet.WORD_PARAMETER, word, AppointmentBookServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/PrettyPrinter.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/PrettyPrinter.java
@@ -18,7 +18,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/Project4.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs410J/apptbookweb/Project4.java
@@ -80,7 +80,7 @@ public class Project4 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 

--- a/projects-parent/originals-parent/apptbook-web/src/site/site.xml
+++ b/projects-parent/originals-parent/apptbook-web/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs410J/apptbookweb/AppointmentBookServletTest.java
@@ -46,8 +46,8 @@ public class AppointmentBookServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(AppointmentBookServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(AppointmentBookServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/originals-parent/apptbook/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/apptbook/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -146,7 +146,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>apptbook</artifactId>
   <packaging>jar</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>CS410J Appointment Book Project</name>
   <description>An Appointment Book application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -43,12 +43,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -30,17 +30,6 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
       <version>2023.0.0-SNAPSHOT</version>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>apptbook</artifactId>
   <packaging>jar</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>CS410J Appointment Book Project</name>
   <description>An Appointment Book application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs410J/apptbook/TextDumper.java
+++ b/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs410J/apptbook/TextDumper.java
@@ -2,11 +2,12 @@ package edu.pdx.cs410J.apptbook;
 
 import edu.pdx.cs410J.AppointmentBookDumper;
 
-import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements AppointmentBookDumper<AppointmentBook> {
   private final Writer writer;
 

--- a/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs410J/apptbook/TextParser.java
+++ b/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs410J/apptbook/TextParser.java
@@ -8,6 +8,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements AppointmentBookParser<AppointmentBook> {
   private final Reader reader;
 

--- a/projects-parent/originals-parent/apptbook/src/site/site.xml
+++ b/projects-parent/originals-parent/apptbook/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/kata/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/kata/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -111,7 +111,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -13,7 +13,7 @@
 
   <name>Kata Project</name>
   <description>A simple project for getting started with code katas</description>
-  <url>http://www.cs.pdx.edu</url>
+  <url>https://www.cs.pdx.edu</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>kata</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>jar</packaging>
 
   <name>Kata Project</name>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>kata</artifactId>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Kata Project</name>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/kata/src/main/java/edu/pdx/cs410J/kata/Kata.java
+++ b/projects-parent/originals-parent/kata/src/main/java/edu/pdx/cs410J/kata/Kata.java
@@ -1,5 +1,7 @@
 package edu.pdx.cs410J.kata;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * A class for getting started with a code kata
  *
@@ -8,6 +10,7 @@ package edu.pdx.cs410J.kata;
  */
 public class Kata {
 
+  @VisibleForTesting
   public static void main(String[] args) {
     System.err.println("Missing command line arguments");
   }

--- a/projects-parent/originals-parent/kata/src/site/site.xml
+++ b/projects-parent/originals-parent/kata/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/phonebill-web/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/phonebill-web/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
@@ -16,7 +16,7 @@
   <packaging>war</packaging>
   <version>2023.0.0-SNAPSHOT</version>
   <name>Phone Bill Web/REST Project</name>
-  <url>http://maven.apache.org</url>
+  <url>https://maven.apache.org</url>
 
   <dependencies>
     <dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,7 +14,7 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>Phone Bill Web/REST Project</name>
   <url>https://maven.apache.org</url>
 
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -138,7 +138,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
@@ -14,7 +14,7 @@
   </properties>
 
   <packaging>war</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>Phone Bill Web/REST Project</name>
   <url>http://maven.apache.org</url>
 
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -60,57 +60,33 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <httpConnector>
-            <port>${jetty.http.port}</port>
-          </httpConnector>
-          <stopKey>stop-key</stopKey>
           <stopPort>9999</stopPort>
+          <stopKey>stop-jetty</stopKey>
           <webApp>
             <contextPath>/${project.build.finalName}</contextPath>
           </webApp>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
-        <version>1.6.7</version>
         <executions>
           <execution>
-            <id>start-container</id>
+            <id>start-jetty</id>
             <phase>pre-integration-test</phase>
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <httpConnector>
+                <port>${jetty.http.port}</port>
+              </httpConnector>
+            </configuration>
           </execution>
           <execution>
-            <id>stop-container</id>
+            <id>stop-jetty</id>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <container>
-            <containerId>jetty9x</containerId>
-            <type>embedded</type>
-            <systemProperties>
-              <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
-            </systemProperties>
-          </container>
-          <configuration>
-            <properties>
-              <cargo.servlet.port>${jetty.http.port}</cargo.servlet.port>
-            </properties>
-          </configuration>
-          <deployables>
-            <deployable>
-              <location>${project.build.directory}/${project.build.finalName}.${project.packaging}</location>
-              <pingURL>http://localhost:${jetty.http.port}/${project.build.finalName}/index.html</pingURL>
-              <pingTimeout>20000</pingTimeout>
-            </deployable>
-          </deployables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClientIT.java
@@ -59,7 +59,7 @@ class PhoneBillRestClientIT {
     RestException ex =
       assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
-    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter("word")));
+    assertThat(ex.getMessage(), equalTo(Messages.missingRequiredParameter(PhoneBillServlet.WORD_PARAMETER)));
   }
 
 }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs410J/phonebillweb/Project4IT.java
@@ -38,6 +38,9 @@ class Project4IT extends InvokeMainTestCase {
     @Test
     void test2EmptyServer() {
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatWordCount(0)));
     }
@@ -61,14 +64,23 @@ class Project4IT extends InvokeMainTestCase {
         String definition = "DEFINITION";
 
         MainMethodResult result = invokeMain( Project4.class, HOSTNAME, PORT, word, definition );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         String out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(Messages.definedWordAs(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT, word );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
 
         result = invokeMain( Project4.class, HOSTNAME, PORT );
+
+        assertThat(result.getTextWrittenToStandardError(), equalTo(""));
+
         out = result.getTextWrittenToStandardOut();
         assertThat(out, out, containsString(PrettyPrinter.formatDictionaryEntry(word, definition)));
     }

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PhoneBillRestClient.java
@@ -45,6 +45,7 @@ public class PhoneBillRestClient {
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
     Response response = http.get(Map.of());
+    throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
     return parser.parse();
@@ -54,7 +55,7 @@ public class PhoneBillRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    Response response = http.get(Map.of("word", word));
+    Response response = http.get(Map.of(PhoneBillServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -63,7 +64,7 @@ public class PhoneBillRestClient {
   }
 
     public void addDictionaryEntry(String word, String definition) throws IOException {
-      Response response = http.post(Map.of("word", word, "definition", definition));
+      Response response = http.post(Map.of(PhoneBillServlet.WORD_PARAMETER, word, PhoneBillServlet.DEFINITION_PARAMETER, definition));
       throwExceptionIfNotOkayHttpStatus(response);
     }
 

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PrettyPrinter.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/PrettyPrinter.java
@@ -18,7 +18,7 @@ public class PrettyPrinter {
   @VisibleForTesting
   static String formatDictionaryEntry(String word, String definition )
   {
-    return String.format("  %s : %s", word, definition);
+    return String.format("  %s -> %s", word, definition);
   }
 
 

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/Project4.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs410J/phonebillweb/Project4.java
@@ -1,7 +1,6 @@
 package edu.pdx.cs410J.phonebillweb;
 
 import edu.pdx.cs410J.ParserException;
-import edu.pdx.cs410J.web.HttpRequestHelper;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -79,24 +78,11 @@ public class Project4 {
             }
 
         } catch (IOException | ParserException ex ) {
-            error("While contacting server: " + ex);
+            error("While contacting server: " + ex.getMessage());
             return;
         }
 
         System.out.println(message);
-    }
-
-    /**
-     * Makes sure that the give response has the expected HTTP status code
-     * @param code The expected status code
-     * @param response The response from the server
-     */
-    private static void checkResponseCode( int code, HttpRequestHelper.Response response )
-    {
-        if (response.getHttpStatusCode() != code) {
-            error(String.format("Expected HTTP code %d, got code %d.\n\n%s", code,
-                                response.getHttpStatusCode(), response.getContent()));
-        }
     }
 
     private static void error( String message )

--- a/projects-parent/originals-parent/phonebill-web/src/site/site.xml
+++ b/projects-parent/originals-parent/phonebill-web/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/PhoneBillServletTest.java
+++ b/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs410J/phonebillweb/PhoneBillServletTest.java
@@ -46,8 +46,8 @@ class PhoneBillServletTest {
     String definition = "TEST DEFINITION";
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    when(request.getParameter("word")).thenReturn(word);
-    when(request.getParameter("definition")).thenReturn(definition);
+    when(request.getParameter(PhoneBillServlet.WORD_PARAMETER)).thenReturn(word);
+    when(request.getParameter(PhoneBillServlet.DEFINITION_PARAMETER)).thenReturn(definition);
 
     HttpServletResponse response = mock(HttpServletResponse.class);
 

--- a/projects-parent/originals-parent/phonebill/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/phonebill/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>phonebill</artifactId>
   <packaging>jar</packaging>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <name>CS410J Phone Bill Project</name>
   <description>A Phone Bill application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -147,7 +147,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>${student.version}</version>
+                <version>${grader.version}</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>phonebill</artifactId>
   <packaging>jar</packaging>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <name>CS410J Phone Bill Project</name>
   <description>A Phone Bill application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -49,12 +49,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId>
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
@@ -13,15 +13,15 @@
   <name>CS410J Phone Bill Project</name>
   <description>A Phone Bill application for CS410J at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
-  <url>http://www.cs.pdx.edu/~whitlock</url>
+  <url>https://www.cs.pdx.edu/~whitlock</url>
   <developers>
     <developer>
       <id>YOU</id>
       <name>Your name here</name>
       <email>you@youremail.com</email>
-      <url>http://www.cs.pdx.edu/~YOU</url>
+      <url>https://www.cs.pdx.edu/~YOU</url>
       <organization>PSU Department of Computer Science</organization>
-      <organizationUrl>http://www.cs.pdx.edu</organizationUrl>
+      <organizationUrl>https://www.cs.pdx.edu</organizationUrl>
       <roles>
         <role>Student</role>
       </roles>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -30,20 +30,9 @@
   </developers>
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/projects-parent/originals-parent/phonebill/src/main/java/edu/pdx/cs410J/phonebill/TextDumper.java
+++ b/projects-parent/originals-parent/phonebill/src/main/java/edu/pdx/cs410J/phonebill/TextDumper.java
@@ -1,12 +1,13 @@
 package edu.pdx.cs410J.phonebill;
 
-import edu.pdx.cs410J.AppointmentBookDumper;
 import edu.pdx.cs410J.PhoneBillDumper;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 
+/**
+ * A skeletal implementation of the <code>TextDumper</code> class for Project 2.
+ */
 public class TextDumper implements PhoneBillDumper<PhoneBill> {
   private final Writer writer;
 

--- a/projects-parent/originals-parent/phonebill/src/main/java/edu/pdx/cs410J/phonebill/TextParser.java
+++ b/projects-parent/originals-parent/phonebill/src/main/java/edu/pdx/cs410J/phonebill/TextParser.java
@@ -7,6 +7,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
+/**
+ * A skeletal implementation of the <code>TextParser</code> class for Project 2.
+ */
 public class TextParser implements PhoneBillParser<PhoneBill> {
   private final Reader reader;
 

--- a/projects-parent/originals-parent/phonebill/src/site/site.xml
+++ b/projects-parent/originals-parent/phonebill/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/TextDumperTest.java
+++ b/projects-parent/originals-parent/phonebill/src/test/java/edu/pdx/cs410J/phonebill/TextDumperTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class TextDumperTest {
 
   @Test
-  void appointmentBookOwnerIsDumpedInTextFormat() {
+  void phoneBillOwnerIsDumpedInTextFormat() {
     String customer = "Test Phone Bill";
     PhoneBill bill = new PhoneBill(customer);
 

--- a/projects-parent/originals-parent/pom.xml
+++ b/projects-parent/originals-parent/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2023.0.0-SNAPSHOT</version>
+        <version>2023.0.0</version>
     </parent>
 
     <artifactId>originals-parent</artifactId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/originals-parent/pom.xml
+++ b/projects-parent/originals-parent/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2022.1.0</version>
+        <version>2023.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>originals-parent</artifactId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/originals-parent/student/.mvn/wrapper/maven-wrapper.properties
+++ b/projects-parent/originals-parent/student/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>student</artifactId>
-  <version>2022.1.0</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Student Project</name>
@@ -88,12 +88,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2022.2.0-SNAPSHOT</version>
+      <version>2023.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -116,7 +116,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>2022.5.0</version>
+                <version>2023.0.0-SNAPSHOT</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <groupId>io.github.davidwhitlock.cs410J.original</groupId>
   <artifactId>student</artifactId>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <packaging>jar</packaging>
 
   <name>Student Project</name>
@@ -88,12 +88,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -116,7 +116,7 @@
               <docletArtifact>
                 <groupId>io.github.davidwhitlock.cs410J</groupId>
                 <artifactId>grader</artifactId>
-                <version>2023.0.0-SNAPSHOT</version>
+                <version>2023.0.0</version>
               </docletArtifact>
               <useStandardDocletOptions>false</useStandardDocletOptions>
               <show>private</show>

--- a/projects-parent/originals-parent/student/src/site/site.xml
+++ b/projects-parent/originals-parent/student/src/site/site.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.11.0</version>
+  </skin>
+  <body>
+    <menu ref="parent"/>
+    <menu ref="modules"/>
+    <menu ref="reports"/>
+  </body>
+  <custom>
+    <fluidoSkin>
+      <googleSearch>
+        <sitesearch/>
+      </googleSearch>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>YourGitHubUser/PortlandStateJavaSummer2022</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>black</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+</project>

--- a/projects-parent/pom.xml
+++ b/projects-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>cs410j</artifactId>
-        <version>2023.0.0-SNAPSHOT</version>
+        <version>2023.0.0</version>
     </parent>
 
     <artifactId>projects-parent</artifactId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/pom.xml
+++ b/projects-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.cs410J</groupId>
         <artifactId>cs410j</artifactId>
-        <version>2022.1.0</version>
+        <version>2023.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>projects-parent</artifactId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -2,13 +2,13 @@
   <parent>
     <artifactId>projects-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>projects</artifactId>
   <name>CS410J Project APIs</name>
   <description>Classes needed for the Projects in CS410J: Advanced Java Programming</description>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <build>
     <plugins>

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -2,13 +2,13 @@
   <parent>
     <artifactId>projects-parent</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>projects</artifactId>
   <name>CS410J Project APIs</name>
   <description>Classes needed for the Projects in CS410J: Advanced Java Programming</description>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <build>
     <plugins>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -106,12 +106,6 @@
       <version>4.0.1</version>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.4</version>
@@ -150,11 +144,6 @@
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
       <version>${guice.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -13,7 +13,7 @@
   <version>2023.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
-    <resteasy.version>6.1.0.Beta2</resteasy.version>
+    <resteasy.version>6.2.1.Final</resteasy.version>
     <jetty.http.port>8080</jetty.http.port>
   </properties>
   <build>
@@ -70,7 +70,7 @@
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>${exec-maven-plugin.version}</version>
           <executions>
             <execution>
               <goals>
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>3.0.0</version>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-guice</artifactId>
-      <version>4.7.3.Final</version>
+      <version>4.7.7.Final</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -39,7 +39,6 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${jetty-maven-plugin.version}</version>
         <configuration>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopPort>9999</stopPort>
           <stopKey>stop-jetty</stopKey>
           <webApp>
@@ -54,8 +53,6 @@
               <goal>start</goal>
             </goals>
             <configuration>
-              <scanIntervalSeconds>0</scanIntervalSeconds>
-              <daemon>true</daemon>
               <httpConnector>
                 <port>${jetty.http.port}</port>
               </httpConnector>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2023.0.0-SNAPSHOT</version>
+    <version>2023.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>web</artifactId>
   <packaging>war</packaging>
   <name>Web Application examples</name>
-  <version>2023.0.0-SNAPSHOT</version>
+  <version>2023.0.0</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <resteasy.version>6.2.1.Final</resteasy.version>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2023.0.0-SNAPSHOT</version>
+      <version>2023.0.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -3,14 +3,14 @@
   <parent>
     <artifactId>cs410j</artifactId>
     <groupId>io.github.davidwhitlock.cs410J</groupId>
-    <version>2022.1.0</version>
+    <version>2023.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.cs410J</groupId>
   <artifactId>web</artifactId>
   <packaging>war</packaging>
   <name>Web Application examples</name>
-  <version>2022.2.0-SNAPSHOT</version>
+  <version>2023.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <resteasy.version>6.1.0.Beta2</resteasy.version>
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.cs410J</groupId>
       <artifactId>examples</artifactId>
-      <version>2022.1.0</version>
+      <version>2023.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
  * Resolve #424 by generating project time estimates for the koans project and generating summary for multiple terms of data
  * Upgraded Jetty to 10.0.11.  This is related to #404.
  * Make small improvements to the REST projects to resolve #423 
  * Resolve #410 by renaming `student.version` to `grader.version`.
  * Resolve #418 by changing the Survey program to reject a student id that is not a Java identifier.
  * Resolve #422 by adding comments that clarify that the TextDumper and TextParser classes are for Project 2.
  * Resolve #420 by making guava a top-level dependency available to all projects
  * Resolve #419 by adding a site.xml to the projects and their archetypes.
  * Updated Maven plugin and third-party dependencies to their latest versions
  * Resolve #425 by not including an assignment in the Grade Summary Report for which all of its grades are zero. Along the way, I got rid of some warnings and code smells.