### PR TITLE
Reject a student id that is not a Java identifier

### DIFF
--- a/grader/src/main/java/edu/pdx/cs410J/grader/Survey.java
+++ b/grader/src/main/java/edu/pdx/cs410J/grader/Survey.java
@@ -132,6 +132,9 @@ public class Survey extends EmailSender {
 
     } else if (isEmailAddress(id)) {
       printErrorMessageAndExit("** Your student id cannot be an email address");
+
+    } else if (!isJavaIdentifier(id)) {
+      printErrorMessageAndExit("** Your student id must be a valid Java identifier");
     }
 
     Student student = new Student(id);
@@ -156,6 +159,26 @@ public class Survey extends EmailSender {
     } catch (AddressException e) {
       return false;
     }
+  }
+
+  @VisibleForTesting
+  static boolean isJavaIdentifier(String id) {
+    if (id == null || id.equals("")) {
+      return false;
+    }
+
+    if (!Character.isJavaIdentifierStart(id.charAt(0))) {
+      return false;
+    }
+
+    for (int i = 1; i < id.length(); i++) {
+      char c = id.charAt(i);
+      if (!Character.isJavaIdentifierPart(c)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   private void askEnrolledSectionQuestion(Student student) {

--- a/grader/src/test/java/edu/pdx/cs410J/grader/SurveyTest.java
+++ b/grader/src/test/java/edu/pdx/cs410J/grader/SurveyTest.java
@@ -68,6 +68,18 @@ public class SurveyTest {
   }
 
   @Test
+  void invalidJavaIdentifierIsInvalid() {
+    String id = "123";
+    assertThat(Survey.isJavaIdentifier(id), equalTo(false));
+  }
+
+  @Test
+  void validJavaIdentifierIsValid() {
+    String id = "whitlock123";
+    assertThat(Survey.isJavaIdentifier(id), equalTo(true));
+  }
+
+  @Test
   void successfulSurveyWritesStudentXmlFile(@TempDir File tempDir) throws IOException, ParserException {
     String firstName = "First name";
     String lastName = "Last name";


### PR DESCRIPTION
Resolve #418 by changing the Survey program to reject a student id that is not a Java identifier.