### PR TITLE
H2 database tools no longer dump stack traces

### DIFF
--- a/examples/src/it/java/edu/pdx/cs/joy/jdbc/ExecuteH2DatabaseStatementIT.java
+++ b/examples/src/it/java/edu/pdx/cs/joy/jdbc/ExecuteH2DatabaseStatementIT.java
@@ -299,5 +299,17 @@ public class ExecuteH2DatabaseStatementIT extends InvokeMainTestCase {
     assertThat(output, containsString("4"));
     assertThat(output, containsString("1 row(s) returned"));
   }
-}
 
+  @Test
+  @Order(15)
+  public void testInvalidStatementPrintsErrorWithoutStackTrace() {
+    MainMethodResult result = invokeMain(ExecuteH2DatabaseStatement.class, dbFilePath,
+        "SELECT * FROM customers");
+    String errorOutput = result.getTextWrittenToStandardError();
+
+    assertThat(errorOutput, containsString("Error:"));
+    assertThat(errorOutput, containsString("Table \"CUSTOMERS\" not found"));
+    assertThat(errorOutput, not(containsString("Exception in thread")));
+    assertThat(errorOutput, not(containsString("\tat ")));
+  }
+}

--- a/examples/src/it/java/edu/pdx/cs/joy/jdbc/PrintH2DatabaseSchemaIT.java
+++ b/examples/src/it/java/edu/pdx/cs/joy/jdbc/PrintH2DatabaseSchemaIT.java
@@ -4,10 +4,12 @@ import edu.pdx.cs.joy.InvokeMainTestCase;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -182,5 +184,17 @@ public class PrintH2DatabaseSchemaIT extends InvokeMainTestCase {
     // Verify the database file path is shown
     assertThat(output, containsString("Reading schema from H2 database:"));
     assertThat(output, containsString(dbFilePath));
+  }
+
+  @Test
+  public void testInvalidDatabasePathPrintsErrorWithoutStackTrace(@TempDir Path tempDirectory) {
+    String invalidDatabasePath = tempDirectory.resolve("missing-db").toAbsolutePath() + ";IFEXISTS=TRUE";
+
+    MainMethodResult result = invokeMain(PrintH2DatabaseSchema.class, invalidDatabasePath);
+    String errorOutput = result.getTextWrittenToStandardError();
+
+    assertThat(errorOutput, containsString("Error:"));
+    assertThat(errorOutput, not(containsString("Exception in thread")));
+    assertThat(errorOutput, not(containsString("\tat ")));
   }
 }

--- a/examples/src/main/java/edu/pdx/cs/joy/jdbc/ExecuteH2DatabaseStatement.java
+++ b/examples/src/main/java/edu/pdx/cs/joy/jdbc/ExecuteH2DatabaseStatement.java
@@ -14,9 +14,8 @@ public class ExecuteH2DatabaseStatement {
    * Main method that takes a database file path and SQL statement as arguments.
    *
    * @param args command line arguments: args[0] = database file path, args[1] = SQL statement
-   * @throws SQLException if a database error occurs
    */
-  public static void main(String[] args) throws SQLException {
+  public static void main(String[] args) {
     if (args.length < 2) {
       System.err.println("Missing required arguments");
       System.err.println("Usage: java ExecuteH2DatabaseStatement <database-file-path> <sql-statement>");
@@ -39,6 +38,8 @@ public class ExecuteH2DatabaseStatement {
 
     try (Connection connection = H2DatabaseHelper.createFileBasedConnection(dbFile)) {
       executeStatement(connection, sqlStatement);
+    } catch (SQLException ex) {
+      System.err.println("Error: " + ex.getMessage());
     }
   }
 

--- a/examples/src/main/java/edu/pdx/cs/joy/jdbc/PrintH2DatabaseSchema.java
+++ b/examples/src/main/java/edu/pdx/cs/joy/jdbc/PrintH2DatabaseSchema.java
@@ -195,9 +195,8 @@ public class PrintH2DatabaseSchema {
    * Main method that takes a database file path and prints the schema.
    *
    * @param args command line arguments where args[0] is the path to the H2 database file
-   * @throws SQLException if a database error occurs
    */
-  public static void main(String[] args) throws SQLException {
+  public static void main(String[] args) {
     if (args.length < 1) {
       System.err.println("Missing database file path argument");
       System.err.println("Usage: java PrintH2DatabaseSchema <database-file-path>");
@@ -212,6 +211,8 @@ public class PrintH2DatabaseSchema {
 
     try (Connection connection = H2DatabaseHelper.createFileBasedConnection(dbFile)) {
       printDatabaseSchema(connection);
+    } catch (SQLException ex) {
+      System.err.println("Error: " + ex.getMessage());
     }
   }
 }


### PR DESCRIPTION
Address #535 by catching `SQLException`s and printing a one-liner message instead of dumping the exception's stack trace.